### PR TITLE
Add Fr. for Father

### DIFF
--- a/sentencex/languages/en.py
+++ b/sentencex/languages/en.py
@@ -72,6 +72,7 @@ class English(Language):
         "fed",
         "fig",
         "fla",
+        "fr",
         "ft",
         "fwy",
         "fy",


### PR DESCRIPTION
Add "Fr.", an abbreviation for Father.