### PR TITLE
Add abbreviations to English

### DIFF
--- a/src/languages/abbrev/en.txt
+++ b/src/languages/abbrev/en.txt
@@ -1,4 +1,5 @@
 A
+abbrev
 adj
 adm
 adv
@@ -24,9 +25,13 @@ brig
 bros
 btw
 C
+ca
 cal
 calif
 capt
+cf
+c.f
+cit
 cl
 cmdr
 co
@@ -51,6 +56,7 @@ dr.phil
 dr.philos
 dr
 drs
+eg
 e.g
 E
 ens
@@ -63,6 +69,8 @@ ext
 F
 feb
 fed
+ff
+f.f
 fig
 fla
 ft
@@ -78,6 +86,9 @@ hosp
 hr
 hway
 hwy
+i.a
+ibid
+ie
 i.e
 I
 ia
@@ -100,6 +111,7 @@ ken
 ky
 L
 la
+loc
 lt
 ltd
 M
@@ -135,8 +147,10 @@ N°
 No̱
 No
 N
+nb
 neb
 nebr
+nem
 nev
 no
 nos
@@ -164,11 +178,18 @@ pl
 plz
 pp
 prof
+ps
+p.s
+pps
 pvt
 Q
+qq
+qq.v
 que
 R
 rd
+re
+reg
 ref
 rep
 reps
@@ -178,6 +199,8 @@ rs
 rt
 S
 sask
+sc
+scil
 sec
 sen
 sens
@@ -185,7 +208,9 @@ sep
 sept
 sfc
 sgt
+s.l
 sr
+s.s
 st
 supt
 surg


### PR DESCRIPTION
- Added a few of the common Latin abbreviations from https://en.wikipedia.org/wiki/List_of_Latin_abbreviations
Includes some variants with and without periods.  Didn't add all of them. Just a small handful of ones I have some familiarity with.

- The abbrev. abbreviation.

- Add variations of existing abbreviations like "ie", "eg"
These variations might be controversial additions since a lot of style guides and dictionaries would probably discourage them - most prefer an all or nothing approach.  Nevertheless it is still common to find writing in the wild that uses things like "eg. some example".

Despite some of these variants being "improper" they have common usage, and as far as I'm aware they are not standalone words that could cause a collision like some other abbreviations so the risk of causing a regression is low.

The Latin abbreviations could potentially be added to some of the other languages with Latin lineage, but I'm not familiar enough to suggest which other languages they would be safe to add to.