### PR TITLE
Add support for multi character quote pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Besides native Rust, bindings for the following programming languages are availa
 
 ## Approach
 
-- If it's a period, it ends a sentence.
-- If the preceding token is in the hand-compiled list of abbreviations, then it doesn't end a sentence.
+- A sentence-terminating punctuation mark (`.`, `?`, `!`, plus language specific terminators like `।` or `။`) ends a sentence by default.
+- Hand-compiled abbreviation lists, exclamation words, numbered references (`See [1]. Next sentence.`), and quote-aware rules (see below) suppress or relocate boundaries where the default rule would over-split.
 
 However, it is not 'period' for many languages. So we will use a list of known punctuations that can cause a sentence break in as many languages as possible.
 
@@ -33,6 +33,10 @@ Sometimes, it is very hard to get the segmentation correct. In such cases this l
 Avoid over engineering to get everything linguistically 100% accurate.
 
 This approach would be suitable for applications like text to speech, machine translation.
+
+### Trade-offs
+
+The opinionated *don't-over-split* stance coexists with several rules that *do* recover real boundaries (numbered references, quote-aware handling, abbreviation/exclamation suppression). The aim is to be conservative where context is ambiguous, while still picking up structural signals that make a split safe.
 
 Consider this example: `We make a good team, you and I. Did you see Albert I. Jones yesterday?`
 

--- a/benches/segment_benchmark.rs
+++ b/benches/segment_benchmark.rs
@@ -152,7 +152,7 @@ fn bench_abbreviation_heavy_text(c: &mut Criterion) {
 }
 
 fn bench_quoted_text(c: &mut Criterion) {
-    let text = r#"She said, "This is the first sentence." He replied, "This is the second one." 
+    let text = r#"She said, "This is the first sentence." He replied, "This is the second one."
                   "What about this?" she asked. "And this!" he exclaimed."#;
 
     c.bench_function("quoted_text", |b| {

--- a/benches/segment_benchmark.rs
+++ b/benches/segment_benchmark.rs
@@ -160,6 +160,22 @@ fn bench_quoted_text(c: &mut Criterion) {
     });
 }
 
+fn bench_quote_heavy_inner_terminators(c: &mut Criterion) {
+    let unit = "He said `hi.` Then ``ok.'' Plus `bye.` And \"done.\" \
+                Also «fini.» And “end.” Repeat. ";
+
+    let text = unit.repeat(200);
+
+    let mut group = c.benchmark_group("quote_heavy_inner_terminators");
+
+    group.throughput(Throughput::Bytes(text.len() as u64));
+    group.bench_function("mixed_closers", |b| {
+        b.iter(|| segment(black_box("en"), black_box(&text)))
+    });
+
+    group.finish();
+}
+
 fn bench_real_wikipedia_sample(c: &mut Criterion) {
     // Sample from a real Wikipedia article
     let text = "The James Webb Space Telescope (JWST) is a space telescope specifically designed \
@@ -188,6 +204,7 @@ criterion_group!(
     bench_paragraph_heavy_text,
     bench_abbreviation_heavy_text,
     bench_quoted_text,
+    bench_quote_heavy_inner_terminators,
     bench_real_wikipedia_sample
 );
 criterion_main!(benches);

--- a/bindings/dotnet/src/lib.rs
+++ b/bindings/dotnet/src/lib.rs
@@ -48,7 +48,7 @@ pub unsafe extern "C" fn sentencex_segment(
                 return SegmentResult {
                     ptr: std::ptr::null_mut(),
                     len: 0,
-                }
+                };
             }
         }
     };
@@ -60,7 +60,7 @@ pub unsafe extern "C" fn sentencex_segment(
                 return SegmentResult {
                     ptr: std::ptr::null_mut(),
                     len: 0,
-                }
+                };
             }
         }
     };
@@ -114,7 +114,7 @@ pub unsafe extern "C" fn sentencex_get_boundaries(
                 return BoundaryResult {
                     ptr: std::ptr::null_mut(),
                     len: 0,
-                }
+                };
             }
         }
     };
@@ -126,7 +126,7 @@ pub unsafe extern "C" fn sentencex_get_boundaries(
                 return BoundaryResult {
                     ptr: std::ptr::null_mut(),
                     len: 0,
-                }
+                };
             }
         }
     };

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,30 +1,116 @@
 use regex::Regex;
-use std::collections::HashMap;
+use std::sync::LazyLock;
 
 pub const ROMAN_NUMERALS: [&str; 20] = [
     "i", "ii", "iii", "iv", "v", "vi", "vii", "viii", "ix", "x", "xi", "xii", "xiii", "xiv", "xv",
     "xvi", "xvii", "xviii", "xix", "xx",
 ];
 
-pub fn get_quote_pairs() -> HashMap<&'static str, &'static str> {
-    let mut quote_pairs = HashMap::new();
-    quote_pairs.insert("\"", "\"");
-    quote_pairs.insert(" '", "'"); // Need a space before ' to avoid capturing don't, l'Avv, etc.
-    quote_pairs.insert("«", "»");
-    quote_pairs.insert("‘", "’");
-    quote_pairs.insert("‚", "‚");
-    quote_pairs.insert("“", "”");
-    quote_pairs.insert("‛", "‛");
-    quote_pairs.insert("„", "“");
-    quote_pairs.insert("»", "«");
-    quote_pairs.insert("‟", "‟");
-    quote_pairs.insert("‹", "›");
-    quote_pairs.insert("《", "》");
-    quote_pairs.insert("「", "」");
-    quote_pairs
+/// A quoted-region delimiter pair used to build [`QUOTES_REGEX`].
+pub struct QuotePair {
+    pub open: &'static str,
+    pub close: &'static str,
+    /// When true, wrap both opener and closer in `\B` (zero-width non-word
+    /// boundary) so the symbol won't match adjacent to an alphanumeric.
+    /// Set for pairs that could collide with contractions or possessives
+    /// (e.g. `'`); unnecessary for unambiguous symbols like `«` or `「`.
+    pub guard: bool,
 }
 
-use std::sync::LazyLock;
+// Order matters: the regex engine tries alternatives left to right, so longer
+// openers/closers must come before shorter ones (e.g. `''` before `'`).
+pub const QUOTE_PAIRS: &[QuotePair] = &[
+    QuotePair {
+        open: "``",
+        close: "''",
+        guard: false,
+    },
+    QuotePair {
+        open: "``",
+        close: "``",
+        guard: false,
+    },
+    QuotePair {
+        open: "''",
+        close: "''",
+        guard: false,
+    },
+    QuotePair {
+        open: "`",
+        close: "'",
+        guard: true,
+    },
+    QuotePair {
+        open: "`",
+        close: "`",
+        guard: true,
+    },
+    QuotePair {
+        open: "'",
+        close: "'",
+        guard: true,
+    },
+    QuotePair {
+        open: "\"",
+        close: "\"",
+        guard: false,
+    },
+    QuotePair {
+        open: "«",
+        close: "»",
+        guard: false,
+    },
+    QuotePair {
+        open: "‘",
+        close: "’",
+        guard: false,
+    },
+    QuotePair {
+        open: "‚",
+        close: "‚",
+        guard: false,
+    },
+    QuotePair {
+        open: "“",
+        close: "”",
+        guard: false,
+    },
+    QuotePair {
+        open: "‛",
+        close: "‛",
+        guard: false,
+    },
+    QuotePair {
+        open: "„",
+        close: "“",
+        guard: false,
+    },
+    QuotePair {
+        open: "»",
+        close: "«",
+        guard: false,
+    },
+    QuotePair {
+        open: "‟",
+        close: "‟",
+        guard: false,
+    },
+    QuotePair {
+        open: "‹",
+        close: "›",
+        guard: false,
+    },
+    QuotePair {
+        open: "《",
+        close: "》",
+        guard: false,
+    },
+    QuotePair {
+        open: "「",
+        close: "」",
+        guard: false,
+    },
+];
 
 pub static PARENS_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"[\(（<{\[](?:[^\)\]}>）]|\\[\)\]}>）])*[\)\]}>）]").unwrap());
@@ -37,14 +123,27 @@ pub static NUMBERED_REFERENCE_REGEX: LazyLock<Regex> =
 
 pub static SPACE_AFTER_SEPARATOR: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\s+").unwrap());
 
+pub static QUOTE_CLOSERS_BY_LEN: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+    let mut v: Vec<&'static str> = QUOTE_PAIRS.iter().map(|p| p.close).collect();
+    v.sort_by_key(|s| std::cmp::Reverse(s.len()));
+    v.dedup();
+    v
+});
+
 pub static QUOTES_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    let quote_pairs = get_quote_pairs();
-    let patterns: Vec<String> = quote_pairs
+    let patterns: Vec<String> = QUOTE_PAIRS
         .iter()
-        .map(|(left, right)| format!(r"{}(?s:.*?){}", regex::escape(left), regex::escape(right)))
+        .map(|p| {
+            let open = regex::escape(p.open);
+            let close = regex::escape(p.close);
+            if p.guard {
+                format!(r"\B{open}\b(?s:.*?[^\s{close}]){close}\B")
+            } else {
+                format!(r"{open}(?s:.*?){close}")
+            }
+        })
         .collect();
-    let quotes_regex_str = patterns.join("|");
-    Regex::new(&quotes_regex_str).unwrap()
+    Regex::new(&patterns.join("|")).unwrap()
 });
 
 pub const EXCLAMATION_WORDS: [&str; 17] = [
@@ -276,15 +375,20 @@ mod tests {
 
     #[test]
     fn test_quotes_regex_all_quote_types() {
-        // Test all quote pairs defined in get_quote_pairs
+        // Test all quote pairs defined in QUOTE_PAIRS
         let test_cases = vec![
             ("Standard double: \"Hello\"", vec!["\"Hello\""]),
             ("Greek: «Γεια σου»", vec!["«Γεια σου»"]),
-            ("Curved single: 'Hi'", vec![" 'Hi'"]),
+            ("Curved single: 'Hi'", vec!["'Hi'"]),
             ("German-style: „Hallo“", vec!["„Hallo“"]),
             ("Single angular: ‹Bonjour›", vec!["‹Bonjour›"]),
             ("CJK: 「こんにちは」", vec!["「こんにちは」"]),
             ("Chinese: 《你好》", vec!["《你好》"]),
+            ("LaTeX double: ``Hello''", vec!["``Hello''"]),
+            ("LaTeX single: `Hello'", vec!["`Hello'"]),
+            ("Single backtick: `Hello`", vec!["`Hello`"]),
+            ("Double backtick: ``Hello``", vec!["``Hello``"]),
+            ("Double apostrophe: ''Hello''", vec!["''Hello''"]),
         ];
 
         for (text, expected) in test_cases {
@@ -348,11 +452,14 @@ mod tests {
     #[test]
     fn test_quotes_regex_debug_pattern() {
         // Let's see what the actual regex pattern looks like
-        let quote_pairs = get_quote_pairs();
-        let patterns: Vec<String> = quote_pairs
+        let patterns: Vec<String> = QUOTE_PAIRS
             .iter()
-            .map(|(left, right)| {
-                format!(r"{}(\n|.)*?{}", regex::escape(left), regex::escape(right))
+            .map(|p| {
+                format!(
+                    r"(?s){}.*?{}",
+                    regex::escape(p.open),
+                    regex::escape(p.close)
+                )
             })
             .collect();
         let quotes_regex_str = patterns.join("|");

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -10,11 +10,11 @@ pub const ROMAN_NUMERALS: [&str; 20] = [
 pub struct QuotePair {
     pub open: &'static str,
     pub close: &'static str,
-    /// When true, wrap both opener and closer in `\B` (zero-width non-word
-    /// boundary) so the symbol won't match adjacent to an alphanumeric.
-    /// Set for pairs that could collide with contractions or possessives
-    /// (e.g. `'`); unnecessary for unambiguous symbols like `«` or `「`.
-    pub guard: bool,
+    /// Set for pairs whose delimiters are ambiguous with non-quote uses
+    /// (e.g. `'` clashes with contractions/possessives, `` ` `` with code
+    /// ticks). The regex builder wraps these with `\B` boundary guards;
+    /// unambiguous symbols like `«` or `「` need no special handling.
+    pub ambiguous: bool,
 }
 
 // Order matters: the regex engine tries alternatives left to right, so longer
@@ -23,92 +23,92 @@ pub const QUOTE_PAIRS: &[QuotePair] = &[
     QuotePair {
         open: "``",
         close: "''",
-        guard: false,
+        ambiguous: false,
     },
     QuotePair {
         open: "``",
         close: "``",
-        guard: false,
+        ambiguous: false,
     },
     QuotePair {
         open: "''",
         close: "''",
-        guard: false,
+        ambiguous: false,
     },
     QuotePair {
         open: "`",
         close: "'",
-        guard: true,
+        ambiguous: true,
     },
     QuotePair {
         open: "`",
         close: "`",
-        guard: true,
+        ambiguous: true,
     },
     QuotePair {
         open: "'",
         close: "'",
-        guard: true,
+        ambiguous: true,
     },
     QuotePair {
         open: "\"",
         close: "\"",
-        guard: false,
+        ambiguous: false,
     },
     QuotePair {
         open: "«",
         close: "»",
-        guard: false,
+        ambiguous: false,
     },
     QuotePair {
         open: "‘",
         close: "’",
-        guard: false,
+        ambiguous: false,
     },
     QuotePair {
         open: "‚",
         close: "‚",
-        guard: false,
+        ambiguous: false,
     },
     QuotePair {
         open: "“",
         close: "”",
-        guard: false,
+        ambiguous: false,
     },
     QuotePair {
         open: "‛",
         close: "‛",
-        guard: false,
+        ambiguous: false,
     },
     QuotePair {
         open: "„",
         close: "“",
-        guard: false,
+        ambiguous: false,
     },
     QuotePair {
         open: "»",
         close: "«",
-        guard: false,
+        ambiguous: false,
     },
     QuotePair {
         open: "‟",
         close: "‟",
-        guard: false,
+        ambiguous: false,
     },
     QuotePair {
         open: "‹",
         close: "›",
-        guard: false,
+        ambiguous: false,
     },
     QuotePair {
         open: "《",
         close: "》",
-        guard: false,
+        ambiguous: false,
     },
     QuotePair {
         open: "「",
         close: "」",
-        guard: false,
+        ambiguous: false,
     },
 ];
 
@@ -130,14 +130,32 @@ pub static QUOTE_CLOSERS_BY_LEN: LazyLock<Vec<&'static str>> = LazyLock::new(|| 
     v
 });
 
+/// Escape `s` so it is safe to interpolate inside a regex character
+/// class `[...]`. `regex::escape`'s public contract only covers the
+/// general regex context, not character classes, so we handle the
+/// four class-special chars explicitly: `\ ] ^ -`.
+fn escape_for_char_class(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if matches!(c, '\\' | ']' | '^' | '-') {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
 pub static QUOTES_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     let mut patterns: Vec<String> = QUOTE_PAIRS
         .iter()
         .map(|p| {
             let open = regex::escape(p.open);
             let close = regex::escape(p.close);
-            if p.guard {
-                format!(r"\B{open}\b(?s:.*?[^\s{close}]){close}\B")
+            if p.ambiguous {
+                // `close_in_class` uses char-class-aware escaping;
+                // `regex::escape` is not contracted safe inside `[...]`.
+                let close_in_class = escape_for_char_class(p.close);
+                format!(r"\B{open}\b(?s:.*?[^\s{close_in_class}]){close}\B")
             } else {
                 format!(r"{open}(?s:.*?){close}")
             }
@@ -152,7 +170,7 @@ pub static QUOTES_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     // Both guards (`\B…\b` opener-side, `[^\s…]…\B` closer-side) are
     // dropped, allowing whitespace immediately inside the quote pair
     // (`' Hello, world. '`).
-    for pair in QUOTE_PAIRS.iter().filter(|p| p.guard) {
+    for pair in QUOTE_PAIRS.iter().filter(|p| p.ambiguous) {
         let open = regex::escape(pair.open);
         let close = regex::escape(pair.close);
         patterns.push(format!(r"(?m:^{open}.+?{close}$)"));
@@ -484,5 +502,42 @@ mod tests {
         // Verify that Greek quotes are in the pattern
         assert!(quotes_regex_str.contains("«"));
         assert!(quotes_regex_str.contains("»"));
+    }
+
+    #[test]
+    fn test_quotes_regex_metachar_closer_is_safe() {
+        // Regression guard for the guarded-branch pattern construction:
+        // if a future QuotePair has a `close` that is a regex character-
+        // class metachar (`]`, `^`, `-`), interpolating it into the
+        // `[^\s...]` class must still produce a valid regex where the
+        // closer behaves as a literal - not as a class operator. We
+        // rebuild the same shape of pattern locally with synthetic
+        // pairs to exercise this without touching the const QUOTE_PAIRS.
+        for &close in &["]", "^", "-"] {
+            let open_lit = "<";
+            let o = regex::escape(open_lit);
+            let c_in_class = escape_for_char_class(close);
+            let c_outside = regex::escape(close);
+            let pat = format!(r"\B{o}\b(?s:.*?[^\s{c_in_class}]){c_outside}\B");
+            let re = Regex::new(&pat)
+                .unwrap_or_else(|e| panic!("pattern {pat:?} failed to compile: {e}"));
+
+            let text = format!("x <hi{close} y");
+            let m = re
+                .find(&text)
+                .unwrap_or_else(|| panic!("expected match in {text:?} with pattern {pat:?}"));
+            assert_eq!(&text[m.start()..m.end()], format!("<hi{close}"));
+        }
+    }
+
+    #[test]
+    fn test_escape_for_char_class() {
+        assert_eq!(escape_for_char_class("'"), "'");
+        assert_eq!(escape_for_char_class("`"), "`");
+        assert_eq!(escape_for_char_class("]"), r"\]");
+        assert_eq!(escape_for_char_class("^"), r"\^");
+        assert_eq!(escape_for_char_class("-"), r"\-");
+        assert_eq!(escape_for_char_class("\\"), r"\\");
+        assert_eq!(escape_for_char_class("a]b^c-d"), r"a\]b\^c\-d");
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -131,7 +131,7 @@ pub static QUOTE_CLOSERS_BY_LEN: LazyLock<Vec<&'static str>> = LazyLock::new(|| 
 });
 
 pub static QUOTES_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    let patterns: Vec<String> = QUOTE_PAIRS
+    let mut patterns: Vec<String> = QUOTE_PAIRS
         .iter()
         .map(|p| {
             let open = regex::escape(p.open);
@@ -143,6 +143,21 @@ pub static QUOTES_REGEX: LazyLock<Regex> = LazyLock::new(|| {
             }
         })
         .collect();
+
+    // Line-anchored variant for guarded openers. A guarded delimiter (e.g.
+    // `'`, `` ` ``) sitting at start-of-line and matched by another `'` at
+    // end-of-line cannot be a possessive: there is no preceding noun to
+    // attach to at line-start, and at line-end the symmetric pairing across
+    // the same line provides structural evidence that this is a quotation.
+    // Both guards (`\B…\b` opener-side, `[^\s…]…\B` closer-side) are
+    // dropped, allowing whitespace immediately inside the quote pair
+    // (`' Hello, world. '`).
+    for pair in QUOTE_PAIRS.iter().filter(|p| p.guard) {
+        let open = regex::escape(pair.open);
+        let close = regex::escape(pair.close);
+        patterns.push(format!(r"(?m:^{open}.+?{close}$)"));
+    }
+
     Regex::new(&patterns.join("|")).unwrap()
 });
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -10,10 +10,11 @@ pub const ROMAN_NUMERALS: [&str; 20] = [
 pub struct QuotePair {
     pub open: &'static str,
     pub close: &'static str,
-    /// Set for pairs whose delimiters are ambiguous with non-quote uses
-    /// (e.g. `'` clashes with contractions/possessives, `` ` `` with code
-    /// ticks). The regex builder wraps these with `\B` boundary guards;
-    /// unambiguous symbols like `«` or `「` need no special handling.
+    /// Set for pairs whose delimiters are ambiguous with non-quote uses — e.g.
+    /// `'` clashes with contractions/possessives, `` ` `` with code ticks (so
+    /// ``don`t`` with a backtick instead of an apostrophe could trigger a
+    /// false-positive match). The regex builder wraps these with `\B` boundary
+    /// guards. Unambiguous symbols like `«` or `「` need no special handling.
     pub ambiguous: bool,
 }
 

--- a/src/languages/language.rs
+++ b/src/languages/language.rs
@@ -6,7 +6,10 @@ use crate::constants::EMAIL_REGEX;
 use crate::constants::EXCLAMATION_WORDS;
 use crate::constants::GLOBAL_SENTENCE_TERMINATORS;
 use crate::constants::PARENS_REGEX;
+use crate::constants::QUOTE_CLOSERS_BY_LEN;
+use crate::constants::QUOTE_PAIRS;
 use crate::constants::QUOTES_REGEX;
+use crate::constants::SPACE_AFTER_SEPARATOR;
 
 static DEFAULT_SENTENCE_BREAK_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     let pattern = format!("[{}]+", GLOBAL_SENTENCE_TERMINATORS.join(""));
@@ -22,6 +25,15 @@ static CONTINUE_AFTER_NONWORD_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^\W*[0-9a-z]").unwrap());
 
 static PARA_SPLIT_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\n[\r]*\n").unwrap());
+
+/// Push `boundary` only if it advances past the last recorded position.
+/// Quote-extension can move a boundary past later regex matches in the same
+/// paragraph; this keeps the boundary list strictly increasing.
+fn push_if_increasing(boundaries: &mut Vec<usize>, boundary: usize) {
+    if boundary > *boundaries.last().unwrap() {
+        boundaries.push(boundary);
+    }
+}
 
 /// Shared helper for languages that continue sentences before month names.
 ///
@@ -88,6 +100,17 @@ impl SkippableRange {
 
     pub fn is_quote(&self) -> bool {
         self.range_type == SkippableRangeType::Quote
+    }
+
+    pub fn is_inner_terminator(&self, text: &str, boundary: usize) -> bool {
+        if !self.is_quote() || boundary >= self.end {
+            return false;
+        }
+
+        let head = &text[..self.end];
+        QUOTE_CLOSERS_BY_LEN
+            .iter()
+            .any(|c| head.ends_with(*c) && boundary + c.len() == self.end)
     }
 }
 
@@ -179,46 +202,34 @@ pub trait Language {
                 .collect();
             let skippable_ranges = self.get_skippable_ranges(paragraph);
 
-            for (start, end) in matches {
-                let mut boundary = self
-                    .find_boundary(paragraph, start, end)
-                    .unwrap_or(usize::MAX);
-
-                if boundary == usize::MAX {
+            'next_match: for (start, end) in matches {
+                let Some(mut boundary) = self.find_boundary(paragraph, start, end) else {
                     continue;
-                }
-
-                let mut in_range = false;
+                };
 
                 for range in &skippable_ranges {
-                    if range.contains(boundary) {
-                        let next_word = self.get_next_word_approx(paragraph, range.end);
-                        let boundary_extend = self.get_boundary_extend(next_word);
-                        if range.is_quote()
-                            && paragraph.ceil_char_boundary(boundary + 1) == range.end
-                            && boundary_extend >= 0
-                        {
-                            boundary = range.end + boundary_extend as usize;
-                            in_range = false;
-                        } else {
-                            in_range = true;
-                        }
-                        break;
+                    if !range.contains(boundary) {
+                        continue;
                     }
+
+                    // Inside a quoted/parens/email range. Either advance past the
+                    // closer (if the boundary sits at an inner terminator) or drop
+                    // this match entirely. Either way, no further extension applies.
+                    if range.is_inner_terminator(paragraph, boundary) {
+                        let next_word = self.get_next_word_approx(paragraph, range.end);
+                        let extend = self.get_boundary_extend(next_word);
+                        if extend >= 0 {
+                            push_if_increasing(
+                                &mut sentence_boundaries,
+                                range.end + extend as usize,
+                            );
+                        }
+                    }
+                    continue 'next_match;
                 }
 
-                if in_range {
-                    continue;
-                }
-
-                // Quote-extension can move a boundary past later regex matches in the
-                // same paragraph. Ignore those stale matches so boundaries stay
-                // strictly increasing instead of slicing backwards later.
-                if boundary <= *sentence_boundaries.last().unwrap() {
-                    continue;
-                }
-
-                sentence_boundaries.push(boundary);
+                boundary = self.extend_past_orphan_closer(paragraph, boundary, &skippable_ranges);
+                push_if_increasing(&mut sentence_boundaries, boundary);
             }
 
             if *sentence_boundaries.last().unwrap() != paragraph.len() {
@@ -333,7 +344,7 @@ pub trait Language {
     /// to skip when positioning the boundary. Used to handle cases like quoted sentences
     /// where the boundary should include trailing punctuation and whitespace.
     fn get_boundary_extend(&self, word: &str) -> i8 {
-        if self.continue_in_next_word(word.trim()) {
+        if self.continue_in_next_word(word.trim()) || CONTINUE_AFTER_NONWORD_REGEX.is_match(word) {
             // not a boundary.
             return -1;
         }
@@ -352,6 +363,61 @@ pub trait Language {
         }
 
         word.ceil_char_boundary(count as usize) as i8
+    }
+
+    /// If `boundary` sits at an orphan trailing quote closer (e.g. `.'` with no
+    /// matching opener captured by `QUOTES_REGEX`), advance past the closer, any
+    /// trailing whitespace, and any stranded terminator that would otherwise
+    /// form a single-punctuation sentence. Returns `boundary` unchanged otherwise.
+    fn extend_past_orphan_closer(
+        &self,
+        paragraph: &str,
+        boundary: usize,
+        skippable_ranges: &[SkippableRange],
+    ) -> usize {
+        // If the next char opens a known quoted range, that quote belongs to
+        // the upcoming sentence — leave the boundary alone.
+        if skippable_ranges.iter().any(|r| r.start == boundary) {
+            return boundary;
+        }
+
+        // For ambiguous pairs (opener == closer, e.g. `'` or `"`) the regex
+        // may fail to pair both ends when they are space-padded. Use parity
+        // of the closer in the preceding text: odd ⇒ unmatched opener exists
+        // ⇒ true orphan (pull it); even ⇒ already paired ⇒ opening a new
+        // phrase (leave it).
+        let is_orphan = |closer: &str| -> bool {
+            let symmetric = QUOTE_PAIRS
+                .iter()
+                .any(|p| p.open == p.close && p.close == closer);
+            !symmetric || paragraph[..boundary].matches(closer).count() % 2 == 1
+        };
+
+        let Some(closer) = QUOTE_CLOSERS_BY_LEN
+            .iter()
+            .find(|c| paragraph[boundary..].starts_with(**c) && is_orphan(c))
+        else {
+            return boundary;
+        };
+
+        let advance_past_space = |pos: usize| {
+            SPACE_AFTER_SEPARATOR
+                .find(&paragraph[pos..])
+                .map_or(pos, |m| pos + m.end())
+        };
+
+        let mut boundary = advance_past_space(boundary + closer.len());
+        // Absorb any stranded terminators (e.g. `'' .`) that would otherwise
+        // form a single-punctuation sentence.
+        while let Some(m) = self
+            .get_sentence_break_regex()
+            .find(&paragraph[boundary..])
+            .filter(|m| m.start() == 0)
+        {
+            boundary = advance_past_space(boundary + m.end());
+        }
+
+        boundary
     }
 
     /// Checks if a potential sentence boundary is actually part of an abbreviation.

--- a/src/languages/language.rs
+++ b/src/languages/language.rs
@@ -26,6 +26,104 @@ static CONTINUE_AFTER_NONWORD_REGEX: LazyLock<Regex> =
 
 static PARA_SPLIT_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\n[\r]*\n").unwrap());
 
+/// True when `closer` is the closing token of a symmetric quote pair —
+/// `'`, `''`, `"`, etc., where opener equals closer. These pairs are
+/// inherently ambiguous: `QUOTES_REGEX` can fail to pair them when they're
+/// space-padded, so callers need extra logic to decide orphanhood.
+fn is_symmetric_quote_closer(closer: &str) -> bool {
+    QUOTE_PAIRS
+        .iter()
+        .any(|p| p.open == p.close && p.close == closer)
+}
+
+/// True when the `closer` token at `boundary` in `paragraph` is an orphan —
+/// either it has no matching opener earlier in the paragraph, or it is a
+/// lone stray with no counterpart anywhere.
+///
+/// Asymmetric closers (`»`, `”`, …) are unambiguous and always orphan once
+/// `QUOTES_REGEX` has had a chance to pair them. For symmetric closers we
+/// inspect the closer's distribution across the paragraph, ignoring any
+/// occurrence already consumed by an asymmetric quote pair.
+fn is_orphan_closer(
+    paragraph: &str,
+    boundary: usize,
+    closer: &str,
+    skippable_ranges: &[SkippableRange],
+) -> bool {
+    if !is_symmetric_quote_closer(closer) {
+        return true;
+    }
+
+    let consumed_by_asymmetric_pair = |idx: usize| {
+        skippable_ranges
+            .iter()
+            .any(|r| r.is_quote() && idx >= r.start && idx < r.end)
+    };
+
+    let (mut before, mut at_or_after) = (0usize, 0usize);
+    for (idx, _) in paragraph.match_indices(closer) {
+        if consumed_by_asymmetric_pair(idx) {
+            continue;
+        }
+        if idx < boundary {
+            before += 1;
+        } else {
+            at_or_after += 1;
+        }
+    }
+
+    let unmatched_opener_before = before % 2 == 1;
+    let lone_stray_at_boundary = before == 0 && at_or_after == 1;
+    unmatched_opener_before || lone_stray_at_boundary
+}
+
+/// True when `range` is a quote range whose opener and closer are the same
+/// token — `''…''`, `'…'`, `"…"`, etc. These pairs are inherently ambiguous
+/// for the regex pairer and need extra scrutiny when they appear to veto a
+/// sentence boundary.
+fn is_symmetric_quote_range(text: &str, range: &SkippableRange) -> bool {
+    if !range.is_quote() {
+        return false;
+    }
+    let span = &text[range.start..range.end];
+    QUOTE_PAIRS
+        .iter()
+        .filter(|p| p.open == p.close)
+        .any(|p| span.len() >= 2 * p.open.len() && span.starts_with(p.open) && span.ends_with(p.close))
+}
+
+/// True when the paragraph contains an odd number of the symmetric quote
+/// token that opens `range`. An odd count guarantees at least one orphan
+/// occurrence — and when that orphan sits earlier than a real downstream
+/// opener, `QUOTES_REGEX` will mispair across a real sentence break. Even
+/// counts are structurally consistent and should be trusted.
+fn symmetric_token_count_is_odd(paragraph: &str, range: &SkippableRange) -> bool {
+    let Some(pair) = QUOTE_PAIRS
+        .iter()
+        .filter(|p| p.open == p.close)
+        .find(|p| paragraph[range.start..].starts_with(p.open))
+    else {
+        return false;
+    };
+
+    paragraph.matches(pair.open).count() % 2 == 1
+}
+
+/// True when `quote` and any parens range in `ranges` partially overlap —
+/// one endpoint inside, the other outside. Full containment in either
+/// direction (a quote wrapping parens, or parens wrapping a quote) is fine
+/// and returns false. Partial overlap is the signature of a greedy
+/// symmetric-pair pairing that crossed what's really a sentence break.
+fn quote_partially_overlaps_parens(quote: &SkippableRange, ranges: &[SkippableRange]) -> bool {
+    ranges
+        .iter()
+        .filter(|r| r.range_type == SkippableRangeType::Parentheses)
+        .any(|p| {
+            (quote.start < p.start && p.start < quote.end && quote.end < p.end)
+                || (p.start < quote.start && quote.start < p.end && p.end < quote.end)
+        })
+}
+
 /// Push `boundary` only if it advances past the last recorded position.
 /// Quote-extension can move a boundary past later regex matches in the same
 /// paragraph; this keeps the boundary list strictly increasing.
@@ -223,6 +321,22 @@ pub trait Language {
                         continue;
                     }
 
+                    // Symmetric-pair quote ranges (`''…''`, `'…'`, `"…"`) are
+                    // greedy: when a paragraph has more than one closer the
+                    // regex can pair across what's really a sentence break.
+                    // Detect that mispairing structurally — the range's
+                    // endpoints straddle a parens boundary, or the paragraph
+                    // has an odd count of the token and there's a strong
+                    // sentence break here — and let the boundary through
+                    // instead of vetoing it.
+                    if is_symmetric_quote_range(paragraph, range)
+                        && (quote_partially_overlaps_parens(range, &skippable_ranges)
+                            || (symmetric_token_count_is_odd(paragraph, range)
+                                && self.has_strong_sentence_break(paragraph, start, end)))
+                    {
+                        continue;
+                    }
+
                     // Inside a quoted/parens/email range. Either advance past the
                     // closer (if the boundary sits at an inner terminator) or drop
                     // this match entirely. Either way, no further extension applies.
@@ -392,39 +506,42 @@ pub trait Language {
             return boundary;
         }
 
-        // For ambiguous pairs (opener == closer, e.g. `'` or `"`) the regex
-        // may fail to pair both ends when they are space-padded. Use parity
-        // of the closer in the preceding text: odd ⇒ unmatched opener exists
-        // ⇒ true orphan (pull it); even ⇒ already paired ⇒ opening a new
-        // phrase (leave it).
-        let is_orphan = |closer: &str| -> bool {
-            let symmetric = QUOTE_PAIRS
-                .iter()
-                .any(|p| p.open == p.close && p.close == closer);
-            if !symmetric {
-                return true;
-            }
-            // Don't count occurrences already consumed as the closer of a
-            // different (asymmetric) quote pair — those have been paired by
-            // QUOTES_REGEX and shouldn't affect parity for leftover symmetric
-            // quotes.
-            let count = paragraph[..boundary]
-                .match_indices(closer)
-                .filter(|(idx, _)| {
-                    !skippable_ranges
-                        .iter()
-                        .any(|r| r.is_quote() && *idx >= r.start && *idx < r.end)
-                })
-                .count();
-            count % 2 == 1
-        };
-
-        let Some(closer) = QUOTE_CLOSERS_BY_LEN
-            .iter()
-            .find(|c| paragraph[boundary..].starts_with(**c) && is_orphan(c))
-        else {
+        // Find an orphan closer starting at `boundary`, if any. Longest first
+        // so `''` wins over `'` when both could match.
+        let Some(closer) = QUOTE_CLOSERS_BY_LEN.iter().find(|c| {
+            paragraph[boundary..].starts_with(**c)
+                && is_orphan_closer(paragraph, boundary, c, skippable_ranges)
+        }) else {
             return boundary;
         };
+
+        // A symmetric closer (`''`, `'`, `"`, …) that follows a terminator+space
+        // and precedes whitespace + a capitalized word is more plausibly the
+        // *opener* of the next sentence than a trailing orphan — but only when
+        // the same token has already been used as a paired opener/closer
+        // earlier in the paragraph. That paired use is the signal that the
+        // text is using this token in opener position too; without it, the
+        // token is more likely a stray closer (e.g. `… do ? ''` with no
+        // earlier opener).
+        if is_symmetric_quote_closer(closer) {
+            let has_earlier_symmetric_pair = skippable_ranges.iter().any(|r| {
+                r.end <= boundary
+                    && is_symmetric_quote_range(paragraph, r)
+                    && paragraph[r.start..].starts_with(*closer)
+            });
+
+            if has_earlier_symmetric_pair {
+                let after = &paragraph[boundary + closer.len()..];
+                let mut chars = after.chars();
+                let first = chars.next();
+                if first.is_some_and(char::is_whitespace) {
+                    let next_non_ws = chars.find(|c| !c.is_whitespace());
+                    if next_non_ws.is_some_and(|c| c.is_ascii_uppercase()) {
+                        return boundary;
+                    }
+                }
+            }
+        }
 
         let advance_past_space = |pos: usize| {
             SPACE_AFTER_SEPARATOR
@@ -490,6 +607,57 @@ pub trait Language {
         let last_word = self.get_last_word(head);
         let exclamation_word = format!("{}!", last_word);
         EXCLAMATION_WORDS.contains(&exclamation_word.as_str())
+    }
+
+    /// True when the terminator at `[start, end)` looks like a confident
+    /// sentence end: a single `.` whose preceding word is a symmetric quote
+    /// closer (`''`, `"`, …) and whose follower starts with a capital letter
+    /// — the `closer + . + UpperWord` shape. Used as a structural escape
+    /// valve for symmetric-pair quote ranges (`''…''`, `'…'`, `"…"`) that the
+    /// non-greedy `QUOTES_REGEX` may have mispaired across a real boundary.
+    ///
+    /// TODO: a starter-word fallback (last_word non-closer + next word in
+    /// language's starter list) belongs here once starter-word infrastructure
+    /// lands on this branch. Until then, only the closer-branch is implemented.
+    fn has_strong_sentence_break(&self, paragraph: &str, start: usize, end: usize) -> bool {
+        if &paragraph[start..end] != "." {
+            return false;
+        }
+        let head = &paragraph[..start];
+
+        // The terminator is typically space-separated from the closer
+        // (`'' .`), so trim trailing whitespace before walking back to find
+        // the last token.
+        let trimmed = head.trim_end();
+
+        let last_word = match trimmed
+            .char_indices()
+            .rfind(|(_, c)| c.is_whitespace() || *c == '.')
+        {
+            Some((i, c)) => &trimmed[i + c.len_utf8()..],
+            None => trimmed,
+        };
+
+        if last_word.is_empty() {
+            return false;
+        }
+
+        if self.is_abbreviation(head, last_word, ".") {
+            return false;
+        }
+
+        if !is_symmetric_quote_closer(last_word) {
+            return false;
+        }
+
+        let next_index = paragraph.ceil_char_boundary(start + 1);
+        let next_word_approx = self.get_next_word_approx(paragraph, next_index);
+
+        next_word_approx
+            .trim_start()
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_uppercase())
     }
 
     /// Returns an approximate substring of the next word(s) starting from the given position.

--- a/src/languages/language.rs
+++ b/src/languages/language.rs
@@ -29,7 +29,10 @@ static PARA_SPLIT_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\n[\r]*
 /// Push `boundary` only if it advances past the last recorded position.
 /// Quote-extension can move a boundary past later regex matches in the same
 /// paragraph; this keeps the boundary list strictly increasing.
+/// Assumes the caller is passing a non empty list of boundaries.
 fn push_if_increasing(boundaries: &mut Vec<usize>, boundary: usize) {
+    debug_assert!(!boundaries.is_empty());
+
     if boundary > *boundaries.last().unwrap() {
         boundaries.push(boundary);
     }
@@ -102,6 +105,14 @@ impl SkippableRange {
         self.range_type == SkippableRangeType::Quote
     }
 
+    /// True if `boundary` lies just before this quote's closing mark — i.e. the
+    /// sentence terminator sits inside the quoted span with only the closer left.
+    /// Opinionated behaviour, but it can help to resolve some real world cases with erroneous
+    /// or ambiguous punctuation placement.
+    ///
+    /// Example: in (start of line) `He said "Hello."`, the `.` boundary is immediately followed
+    /// by the closing `"`, so the sentence should extend past the quote rather than break
+    /// between the `.` and the `"`.
     pub fn is_inner_terminator(&self, text: &str, boundary: usize) -> bool {
         if !self.is_quote() || boundary >= self.end {
             return false;
@@ -422,10 +433,11 @@ pub trait Language {
         };
 
         let mut boundary = advance_past_space(boundary + closer.len());
+        let sentence_break_regex = self.get_sentence_break_regex();
+
         // Absorb any stranded terminators (e.g. `'' .`) that would otherwise
         // form a single-punctuation sentence.
-        while let Some(m) = self
-            .get_sentence_break_regex()
+        while let Some(m) = sentence_break_regex
             .find(&paragraph[boundary..])
             .filter(|m| m.start() == 0)
         {

--- a/src/languages/language.rs
+++ b/src/languages/language.rs
@@ -390,7 +390,22 @@ pub trait Language {
             let symmetric = QUOTE_PAIRS
                 .iter()
                 .any(|p| p.open == p.close && p.close == closer);
-            !symmetric || paragraph[..boundary].matches(closer).count() % 2 == 1
+            if !symmetric {
+                return true;
+            }
+            // Don't count occurrences already consumed as the closer of a
+            // different (asymmetric) quote pair — those have been paired by
+            // QUOTES_REGEX and shouldn't affect parity for leftover symmetric
+            // quotes.
+            let count = paragraph[..boundary]
+                .match_indices(closer)
+                .filter(|(idx, _)| {
+                    !skippable_ranges
+                        .iter()
+                        .any(|r| r.is_quote() && *idx >= r.start && *idx < r.end)
+                })
+                .count();
+            count % 2 == 1
         };
 
         let Some(closer) = QUOTE_CLOSERS_BY_LEN

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 use languages::{
     Amharic, Arabic, Armenian, Bengali, Bulgarian, Burmese, Catalan, Danish, Dutch, English,
     Finnish, French, German, Greek, Gujarati, Hindi, Italian, Japanese, Kannada, Kazakh, Language,
-    Malayalam, Marathi, Polish, Portuguese, Punjabi, Russian, Slovak, Spanish, Tamil, Telugu, Ukrainian,
+    Malayalam, Marathi, Polish, Portuguese, Punjabi, Russian, Slovak, Spanish, Tamil, Telugu,
+    Ukrainian,
 };
 use regex::Regex;
 use std::sync::LazyLock;
@@ -322,7 +323,8 @@ mod tests {
             if case.is_empty() || case.starts_with('#') {
                 continue; // Skip comment and empty lines
             }
-            let parts: Vec<&str> = case.split("---")
+            let parts: Vec<&str> = case
+                .split("---")
                 .map(|part| part.trim())
                 .filter(|part| !part.is_empty())
                 .collect();
@@ -332,7 +334,8 @@ mod tests {
             assert_eq!(parts.len(), 2, "Malformed test case: \n{}", case);
 
             let input = parts[0];
-            let expected: Vec<&str> = parts[1].lines()
+            let expected: Vec<&str> = parts[1]
+                .lines()
                 .map(|line| line.trim())
                 .filter(|line| !line.is_empty())
                 .collect();

--- a/tests/en.txt
+++ b/tests/en.txt
@@ -326,3 +326,80 @@ Dr. Smith, who arrived at 3:00 p.m., said, "The patient's condition is stable; h
 Dr. Smith, who arrived at 3:00 p.m., said, "The patient's condition is stable; however, further tests (e.g., MRI, CT scan) are required.".
 Meanwhile, the nurse—who had been on duty since 7:00 a.m.—noted that the patient's vitals (BP: 120/80, HR: 75) were within normal limits.
 "Let's proceed with the tests ASAP," she added.
+===
+He said `opens with a different symbol to what is used to close it.' Next sentence. "He said `hello world.' and left."
+---
+He said `opens with a different symbol to what is used to close it.'
+Next sentence.
+"He said `hello world.' and left."
+===
+He said ``opens with a different symbol to what is used to close it.'' Next sentence. "He said ``hello world.'' and left."
+---
+He said ``opens with a different symbol to what is used to close it.''
+Next sentence.
+"He said ``hello world.'' and left."
+===
+He said `opens with a different symbol to what is used to close it.` Next sentence. "He said `hello world.` and left."
+---
+He said `opens with a different symbol to what is used to close it.`
+Next sentence.
+"He said `hello world.` and left."
+===
+He said ``opens with a different symbol to what is used to close it.`` Next sentence. "He said ``hello world.`` and left."
+---
+He said ``opens with a different symbol to what is used to close it.``
+Next sentence.
+"He said ``hello world.`` and left."
+===
+'opens with a different symbol to what is used to close it.' Next sentence.
+---
+'opens with a different symbol to what is used to close it.'
+Next sentence.
+===
+It's fine, `just use L'Hôpital's rule here.'
+---
+It's fine, `just use L'Hôpital's rule here.'
+===
+it`s fine to leave it's foods' smells to the cat`s nose
+---
+it`s fine to leave it's foods' smells to the cat`s nose
+===
+Vincent Cartier , Walter 's brother and manager , later reflected on his observations of Kubrick during the filming . He said , '' Stanley was very stoic , impassive but imaginative type person with strong , imaginative thoughts .
+---
+Vincent Cartier , Walter 's brother and manager , later reflected on his observations of Kubrick during the filming .
+He said , '' Stanley was very stoic , impassive but imaginative type person with strong , imaginative thoughts .
+===
+Walter 's brother . He said , ' Stanley .
+---
+Walter 's brother .
+He said , ' Stanley .
+===
+Wendy Schaal ( born July 2 , 1954 ) is an American actress and voice actress . She is best known as the voice of Francine Smith in the TV series '' American Dad ! '' .
+---
+Wendy Schaal ( born July 2 , 1954 ) is an American actress and voice actress . 
+She is best known as the voice of Francine Smith in the TV series '' American Dad ! '' .
+===
+While the Gonarch is not encountered in '' Half - Life 2 '' , an amputated part of it exists as an unused model in the game 's code . This fusion of living material with technology is entirely in keeping with the Combine forces that are encountered in '' Half - Life 2 '' .
+---
+While the Gonarch is not encountered in '' Half - Life 2 '' , an amputated part of it exists as an unused model in the game 's code . 
+This fusion of living material with technology is entirely in keeping with the Combine forces that are encountered in '' Half - Life 2 '' .
+===
+This version also appeared on Sebadoh 's 1992 compilation album '' Smash Your Head on the Punk Rock '' . It also appeared on a number of various artist compilations , including the City Slang compilation '' Slanged ! '' , and the Eurostar compilation '' Going Underground Vol. II '' .
+---
+This version also appeared on Sebadoh 's 1992 compilation album '' Smash Your Head on the Punk Rock '' . 
+It also appeared on a number of various artist compilations , including the City Slang compilation '' Slanged ! '' , and the Eurostar compilation '' Going Underground Vol. II '' .
+===
+According to the publisher Random House , she is the originator of the '' service dog '' , dogs that are trained to help people with mobility limitations .
+---
+According to the publisher Random House , she is the originator of the '' service dog '' , dogs that are trained to help people with mobility limitations .
+===
+Desprez is also known as a designer and maker of embroidery for purses , as a ' Maistre Boursier . ' He published a map of La Rochelle , and was recorded working in Paris between 1556 and 1580 .
+---
+Desprez is also known as a designer and maker of embroidery for purses , as a ' Maistre Boursier . ' 
+He published a map of La Rochelle , and was recorded working in Paris between 1556 and 1580 .
+===
+Gagan Kokri is an punjabi singer . ' Blessings of Baapu ' and ' Asla ' is his Best ever hits .
+---
+Gagan Kokri is an punjabi singer . 
+' Blessings of Baapu ' and ' Asla ' is his Best ever hits .
+===

--- a/tests/en.txt
+++ b/tests/en.txt
@@ -408,3 +408,7 @@ Kate Owen looked at him and said quietly, `And what do you remember next?'  ' I 
 Kate Owen looked at him and said quietly, `And what do you remember next?' 
 ' I was in bed, in the infirmary, with bandages.'
 ===
+' No, they'll not catch you again.  If they try, they'll have Kate Owen to reckon with.'
+---
+' No, they'll not catch you again.  If they try, they'll have Kate Owen to reckon with.'
+===

--- a/tests/en.txt
+++ b/tests/en.txt
@@ -403,3 +403,8 @@ Gagan Kokri is an punjabi singer . ' Blessings of Baapu ' and ' Asla ' is his Be
 Gagan Kokri is an punjabi singer . 
 ' Blessings of Baapu ' and ' Asla ' is his Best ever hits .
 ===
+Kate Owen looked at him and said quietly, `And what do you remember next?'  ' I was in bed, in the infirmary, with bandages.'
+---
+Kate Owen looked at him and said quietly, `And what do you remember next?' 
+' I was in bed, in the infirmary, with bandages.'
+===

--- a/tests/en.txt
+++ b/tests/en.txt
@@ -412,3 +412,28 @@ Kate Owen looked at him and said quietly, `And what do you remember next?'
 ---
 ' No, they'll not catch you again.  If they try, they'll have Kate Owen to reckon with.'
 ===
+Do you know what it means not to know what to do ? '' Graham was ultimately convicted . The informant was immediately released from jail , her sentence commuted to time served .
+---
+Do you know what it means not to know what to do ? ''
+Graham was ultimately convicted .
+The informant was immediately released from jail , her sentence commuted to time served .
+===
+Bloodlines '' ( also known as '' Wrong Turn 5 '' ) is a 2012 American horror film written and directed by Declan O'Brien . It is a prequel and the fifth ( chronologically , the second ) installment in the '' Wrong Turn '' film series .
+---
+Bloodlines '' ( also known as '' Wrong Turn 5 '' ) is a 2012 American horror film written and directed by Declan O'Brien .
+It is a prequel and the fifth ( chronologically , the second ) installment in the '' Wrong Turn '' film series .
+===
+He became notable in the media in 1999 for being one of two councillors to opt out of retroactive salary increases that council had implemented , saying '' ... what the ( salary ) committee recommended was fair and appropriate , but the timing was wrong . It should be for the next council term which would give the electorate time to pass comment on councillors '' remuneration .
+---
+He became notable in the media in 1999 for being one of two councillors to opt out of retroactive salary increases that council had implemented , saying '' ... what the ( salary ) committee recommended was fair and appropriate , but the timing was wrong . It should be for the next council term which would give the electorate time to pass comment on councillors '' remuneration .
+===
+'' The internet exploded with questions about ( Janay Rice ) , '' she wrote . '' Why did n't she leave ?
+---
+'' The internet exploded with questions about ( Janay Rice ) , '' she wrote .
+'' Why did n't she leave ?
+===
+And the music has a melody and a language in and of itself '' . Lead editor Naomi Zeichner went on to compare the album to the work of Interpol and '' the retro biker bar rock that soundtracks '' Sons of Anarchy '' '' .
+---
+And the music has a melody and a language in and of itself '' .
+Lead editor Naomi Zeichner went on to compare the album to the work of Interpol and '' the retro biker bar rock that soundtracks '' Sons of Anarchy '' '' .
+===


### PR DESCRIPTION
Multi character quotes and asymmetric backtick-apostrophe arrangements show up in text in a few different situations:
- Tex / LaTeX typesetting. This is probably a niche use case since people aren't usually interested in sentence splitting LaTeX source code.  e.g.,
```
``Some quote,'' they said.
`Some quote,' they said.
```

- Text from when people adopted old typewriter conventions. More common is when people have been digitising old books and that's what the OCR engine outputs. Also common on wikimedia text.
```
''Some quote''
```

- OCR engine recognition errors.  Sometimes an OCR engine might unintentionally output
```
`this quote'
`this quote`
``this quote.``
it`s fine to leave it's foods' smells to the cat`s nose
```

- Some incidental style clean-ups from cargo fmt
- Introduces a `QuotePair` model
You can specify things like ```QuotePair{open: "'", close: "'", guard: true}``` without needing to add an extra space character in front of the opening string.

- Replace `get_quote_pairs()` with a `QUOTE_PAIRS` slice
- Introduce guard property to QuotePair that uses boundary guards to prevent contraction matching
- Order of `QUOTE_PAIRS` array is significant for matching order

- `SkippablerRange::is_inner_terminator` detects when a candidate boundary sits before the closer of a range.
- `get_sentence_boundaries`: when a boundary lands inside a skippable range, advance past the closer if it's an inner terminator and the next word allows breaking, or drop the match.
- `extend_past_orphan_closer`: if a boundary lands on an unpaired closer, pull the boundary past the closer, spaces and stranded terminators.  For symmetric pairs, it looks at the parity of closer occurrences to decide whether it is an orphan.
- `get_boundary_extend`: returns -1 if `CONTINUE_AFTER_NONWORD_REGEX` to prevent breaks before lowercase/digit continuations.

- Added new tests to cover quotes and potential interactions with contractives/possessives. Some of these are sourced from the Wikisplit English test set.

This improves the F1 score on the WikiSplit test dataset from 99.2 to 99.7.




