### PR TITLE
Normalise newline handling so tests run in windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/*.txt text eol=lf

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -74,19 +74,30 @@ mod tests {
 
     pub fn run_language_tests<T: Language>(language: T, test_file: &str) {
         let content = fs::read_to_string(test_file).expect("Failed to read test file");
-        let test_cases: Vec<&str> = content.split("===\n").collect();
+        // Split on the bare delimiters (no trailing `\n`) so CRLF-checkout files
+        // on Windows parse identically to LF files on Linux/macOS.
+        let test_cases: Vec<&str> = content.split("===").collect();
 
         for case in test_cases {
-            if case.trim().starts_with('#') {
-                continue; // Skip comment lines
+            let case = case.trim();
+            if case.is_empty() || case.starts_with('#') {
+                continue;
             }
-            let parts: Vec<&str> = case.split("---\n").collect();
+            let parts: Vec<&str> = case
+                .split("---")
+                .map(|part| part.trim())
+                .filter(|part| !part.is_empty())
+                .collect();
             if parts.len() != 2 {
                 continue; // Skip malformed test cases
             }
 
-            let input = parts[0].trim();
-            let expected: Vec<&str> = parts[1].lines().map(|line| line.trim()).collect();
+            let input = parts[0];
+            let expected: Vec<&str> = parts[1]
+                .lines()
+                .map(|line| line.trim())
+                .filter(|line| !line.is_empty())
+                .collect();
             let result = language.segment(input);
             let trimmed_result: Vec<String> =
                 result.iter().map(|item| item.trim().to_string()).collect();


### PR DESCRIPTION
Tweak the test data parsing so that it's tolerant of the CRLF newlines in Windows. Otherwise running
```cargo test``` on a Windows machine will silently fail and the tests look like they all pass.

This patch does 2 things:
- Relax the matching strings on the test data parsing to allow handling of both ```\r\n``` and ```\n```
- Change ```.gitattributes``` so new people who check out the repo will have the test data files standardised to just ```\n```.