### PR TITLE
Add support for multi character quote pairs

### DIFF
--- a/benches/segment_benchmark.rs
+++ b/benches/segment_benchmark.rs
@@ -152,12 +152,28 @@ fn bench_abbreviation_heavy_text(c: &mut Criterion) {
 }
 
 fn bench_quoted_text(c: &mut Criterion) {
-    let text = r#"She said, "This is the first sentence." He replied, "This is the second one." 
+    let text = r#"She said, "This is the first sentence." He replied, "This is the second one."
                   "What about this?" she asked. "And this!" he exclaimed."#;
 
     c.bench_function("quoted_text", |b| {
         b.iter(|| segment(black_box("en"), black_box(text)))
     });
+}
+
+fn bench_quote_heavy_inner_terminators(c: &mut Criterion) {
+    let unit = "He said `hi.` Then ``ok.'' Plus `bye.` And \"done.\" \
+                Also «fini.» And “end.” Repeat. ";
+    
+    let text = unit.repeat(200);
+
+    let mut group = c.benchmark_group("quote_heavy_inner_terminators");
+    
+    group.throughput(Throughput::Bytes(text.len() as u64));
+    group.bench_function("mixed_closers", |b| {
+        b.iter(|| segment(black_box("en"), black_box(&text)))
+    });
+
+    group.finish();
 }
 
 fn bench_real_wikipedia_sample(c: &mut Criterion) {
@@ -188,6 +204,7 @@ criterion_group!(
     bench_paragraph_heavy_text,
     bench_abbreviation_heavy_text,
     bench_quoted_text,
+    bench_quote_heavy_inner_terminators,
     bench_real_wikipedia_sample
 );
 criterion_main!(benches);

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,28 +1,42 @@
 use regex::Regex;
-use std::collections::HashMap;
 
 pub const ROMAN_NUMERALS: [&str; 20] = [
     "i", "ii", "iii", "iv", "v", "vi", "vii", "viii", "ix", "x", "xi", "xii", "xiii", "xiv", "xv",
     "xvi", "xvii", "xviii", "xix", "xx",
 ];
 
-pub fn get_quote_pairs() -> HashMap<&'static str, &'static str> {
-    let mut quote_pairs = HashMap::new();
-    quote_pairs.insert("\"", "\"");
-    quote_pairs.insert(" '", "'"); // Need a space before ' to avoid capturing don't, l'Avv, etc.
-    quote_pairs.insert("«", "»");
-    quote_pairs.insert("‘", "’");
-    quote_pairs.insert("‚", "‚");
-    quote_pairs.insert("“", "”");
-    quote_pairs.insert("‛", "‛");
-    quote_pairs.insert("„", "“");
-    quote_pairs.insert("»", "«");
-    quote_pairs.insert("‟", "‟");
-    quote_pairs.insert("‹", "›");
-    quote_pairs.insert("《", "》");
-    quote_pairs.insert("「", "」");
-    quote_pairs
+// `guard` wraps both opener and closer in `\B` (zero-width non-word boundary) so the symbol
+//  won't match adjacent to an alphanumeric. Set for pairs that could collide, or impact
+//  contractions and possessives, e.g., for '.
+//  Unnecessary for unambiguous symbols like «,「.
+pub struct QuotePair {
+    pub open: &'static str,
+    pub close: &'static str,
+    pub guard: bool,
 }
+
+// Quote pairs in the order you want the regex engine to try in.  In practice this means
+// putting the longer openers and closers before the shorter ones,
+// e.g., so '' is resolved before '.
+pub const QUOTE_PAIRS: &[QuotePair] = &[
+    QuotePair { open: "``", close: "''", guard: false },
+    QuotePair { open: "``",  close: "``",  guard: false  },
+    QuotePair { open: "`",  close: "'",  guard: true  },
+    QuotePair { open: "`",  close: "`",  guard: true  },
+    QuotePair { open: "'",  close: "'",  guard: true  },
+    QuotePair { open: "\"", close: "\"", guard: false },
+    QuotePair { open: "«", close: "»", guard: false },
+    QuotePair { open: "‘", close: "’", guard: false },
+    QuotePair { open: "‚", close: "‚", guard: false },
+    QuotePair { open: "“", close: "”", guard: false },
+    QuotePair { open: "‛", close: "‛", guard: false },
+    QuotePair { open: "„", close: "“", guard: false },
+    QuotePair { open: "»", close: "«", guard: false },
+    QuotePair { open: "‟", close: "‟", guard: false },
+    QuotePair { open: "‹", close: "›", guard: false },
+    QuotePair { open: "《", close: "》", guard: false },
+    QuotePair { open: "「", close: "」", guard: false },
+];
 
 use std::sync::LazyLock;
 
@@ -37,14 +51,27 @@ pub static NUMBERED_REFERENCE_REGEX: LazyLock<Regex> =
 
 pub static SPACE_AFTER_SEPARATOR: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\s+").unwrap());
 
+pub static QUOTE_CLOSERS_BY_LEN: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+    let mut v: Vec<&'static str> = QUOTE_PAIRS.iter().map(|p| p.close).collect();
+    v.sort_by(|a, b| b.len().cmp(&a.len()));
+    v.dedup();
+    v
+});
+
 pub static QUOTES_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    let quote_pairs = get_quote_pairs();
-    let patterns: Vec<String> = quote_pairs
+    let patterns: Vec<String> = QUOTE_PAIRS
         .iter()
-        .map(|(left, right)| format!(r"{}(?s:.*?){}", regex::escape(left), regex::escape(right)))
+        .map(|p| {
+            let open = regex::escape(p.open);
+            let close = regex::escape(p.close);
+            if p.guard {
+                format!(r"\B{open}\b(?s:.*?){close}\B")
+            } else {
+                format!(r"{open}(?s:.*?){close}")
+            }
+        })
         .collect();
-    let quotes_regex_str = patterns.join("|");
-    Regex::new(&quotes_regex_str).unwrap()
+    Regex::new(&patterns.join("|")).unwrap()
 });
 
 pub const EXCLAMATION_WORDS: [&str; 17] = [
@@ -276,15 +303,19 @@ mod tests {
 
     #[test]
     fn test_quotes_regex_all_quote_types() {
-        // Test all quote pairs defined in get_quote_pairs
+        // Test all quote pairs defined in QUOTE_PAIRS
         let test_cases = vec![
             ("Standard double: \"Hello\"", vec!["\"Hello\""]),
             ("Greek: «Γεια σου»", vec!["«Γεια σου»"]),
-            ("Curved single: 'Hi'", vec![" 'Hi'"]),
+            ("Curved single: 'Hi'", vec!["'Hi'"]),
             ("German-style: „Hallo“", vec!["„Hallo“"]),
             ("Single angular: ‹Bonjour›", vec!["‹Bonjour›"]),
             ("CJK: 「こんにちは」", vec!["「こんにちは」"]),
             ("Chinese: 《你好》", vec!["《你好》"]),
+            ("LaTeX double: ``Hello''", vec!["``Hello''"]),
+            ("LaTeX single: `Hello'", vec!["`Hello'"]),
+            ("Single backtick: `Hello`", vec!["`Hello`"]),
+            ("Double backtick: ``Hello``", vec!["``Hello``"]),
         ];
 
         for (text, expected) in test_cases {
@@ -348,12 +379,9 @@ mod tests {
     #[test]
     fn test_quotes_regex_debug_pattern() {
         // Let's see what the actual regex pattern looks like
-        let quote_pairs = get_quote_pairs();
-        let patterns: Vec<String> = quote_pairs
+        let patterns: Vec<String> = QUOTE_PAIRS
             .iter()
-            .map(|(left, right)| {
-                format!(r"{}(\n|.)*?{}", regex::escape(left), regex::escape(right))
-            })
+            .map(|p| format!(r"{}(\n|.)*?{}", regex::escape(p.open), regex::escape(p.close)))
             .collect();
         let quotes_regex_str = patterns.join("|");
 

--- a/src/languages/language.rs
+++ b/src/languages/language.rs
@@ -7,6 +7,7 @@ use crate::constants::EXCLAMATION_WORDS;
 use crate::constants::GLOBAL_SENTENCE_TERMINATORS;
 use crate::constants::PARENS_REGEX;
 use crate::constants::QUOTES_REGEX;
+use crate::constants::QUOTE_CLOSERS_BY_LEN;
 
 static DEFAULT_SENTENCE_BREAK_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     let pattern = format!("[{}]+", GLOBAL_SENTENCE_TERMINATORS.join(""));
@@ -88,6 +89,18 @@ impl SkippableRange {
 
     pub fn is_quote(&self) -> bool {
         self.range_type == SkippableRangeType::Quote
+    }
+
+    pub fn is_inner_terminator(&self, text: &str, boundary: usize) -> bool {
+        if !self.is_quote() || boundary >= self.end {
+            return false;
+        }
+        
+        let head = &text[..self.end];
+        QUOTE_CLOSERS_BY_LEN
+            .iter()
+            .find(|c| head.ends_with(*c))
+            .is_some_and(|c| boundary + c.len() == self.end)
     }
 }
 
@@ -194,8 +207,7 @@ pub trait Language {
                     if range.contains(boundary) {
                         let next_word = self.get_next_word_approx(paragraph, range.end);
                         let boundary_extend = self.get_boundary_extend(next_word);
-                        if range.is_quote()
-                            && paragraph.ceil_char_boundary(boundary + 1) == range.end
+                        if range.is_inner_terminator(paragraph, boundary)
                             && boundary_extend >= 0
                         {
                             boundary = range.end + boundary_extend as usize;

--- a/tests/en.txt
+++ b/tests/en.txt
@@ -326,3 +326,41 @@ Dr. Smith, who arrived at 3:00 p.m., said, "The patient's condition is stable; h
 Dr. Smith, who arrived at 3:00 p.m., said, "The patient's condition is stable; however, further tests (e.g., MRI, CT scan) are required.".
 Meanwhile, the nurse—who had been on duty since 7:00 a.m.—noted that the patient's vitals (BP: 120/80, HR: 75) were within normal limits.
 "Let's proceed with the tests ASAP," she added.
+===
+He said `opens with a different symbol to what is used to close it.' Next sentence. "He said `hello world.' and left."
+---
+He said `opens with a different symbol to what is used to close it.'
+Next sentence.
+"He said `hello world.' and left."
+===
+He said ``opens with a different symbol to what is used to close it.'' Next sentence. "He said ``hello world.'' and left."
+---
+He said ``opens with a different symbol to what is used to close it.''
+Next sentence.
+"He said ``hello world.'' and left."
+===
+He said `opens with a different symbol to what is used to close it.` Next sentence. "He said `hello world.` and left."
+---
+He said `opens with a different symbol to what is used to close it.`
+Next sentence.
+"He said `hello world.` and left."
+===
+He said ``opens with a different symbol to what is used to close it.`` Next sentence. "He said ``hello world.`` and left."
+---
+He said ``opens with a different symbol to what is used to close it.``
+Next sentence.
+"He said ``hello world.`` and left."
+===
+'opens with a different symbol to what is used to close it.' Next sentence.
+---
+'opens with a different symbol to what is used to close it.'
+Next sentence.
+===
+It's fine, `just use L'Hôpital's rule here.'
+---
+It's fine, `just use L'Hôpital's rule here.'
+===
+it`s fine to leave it's foods' smells to the cat`s nose
+---
+it`s fine to leave it's foods' smells to the cat`s nose
+===


### PR DESCRIPTION
- Change quote pairs from a hash to a const array
- Introduce guard property to QuotePair that adds boundary guards to the regex expression.
- Modify get_sentence_boundaries to support multi character quote pairs
- Add quote heavy benchmark