### PR TITLE
List handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,18 +812,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,8 +690,10 @@ version = "0.1.24"
 dependencies = [
  "clap",
  "criterion",
+ "memchr",
  "regex",
  "serde",
+ "strum",
 ]
 
 [[package]]
@@ -807,6 +809,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ regex = "1.12.2"
 clap = { version = "4.5.2", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 memchr = { version = "2" }
-strum = { version = "0.27", features = ["derive"] }
+strum = { version = "0.28", features = ["derive"] }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ name = "sentencex"
 regex = "1.12.2"
 clap = { version = "4.5.2", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
+memchr = { version = "2" }
+strum = { version = "0.27", features = ["derive"] }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/README.md
+++ b/README.md
@@ -22,12 +22,9 @@ Besides native Rust, bindings for the following programming languages are availa
 
 ## Approach
 
-- A sentence-terminating punctuation mark (`.`, `?`, `!`, plus language specific terminators like `।` or `။`) ends a sentence by default.
-- Hand-compiled abbreviation lists, exclamation words, numbered references (`See [1]. Next sentence.`), and quote-aware rules (see below) suppress or relocate boundaries where the default rule would over-split.
-
-However, it is not 'period' for many languages. So we will use a list of known punctuations that can cause a sentence break in as many languages as possible.
-
-We also collect a list of known, popular abbreviations in as many languages as possible.
+- A sentence-terminating punctuation mark (`.`, `?`, `!`, plus language specific terminators like `।` or `။`) ends a sentence by default. Some languages use different terminators so a list of known terminator symbols is maintained for supported languages.
+- Hand-compiled abbreviation lists, exclamation words, numbered references (`See [1]. Next sentence.`), and quote-aware rules (see below) suppress or relocate boundaries where the default rule would over-split. We collect a list of known, popular abbreviations in supported languages.
+- List-item starts (e.g., bullets `*` / `+` / `-` / `•`, numeric `1.` / `1)` / `(1)`, lettered `a)` / `(a)`, roman `ii.`) emit sentence boundaries so each item segments cleanly, even when items are written inline on one line. A sibling rule (≥2 matches of the same marker family per paragraph, or a single Tier-1 line-start) keeps prose with stray `(1894)` or `e. e. cummings` from being mis-split.
 
 Sometimes, it is very hard to get the segmentation correct. In such cases this library is opinionated and prefer not segmenting than wrong segmentation. If two sentences are accidentally together, that is ok. It is better than sentence being split in middle.
 Avoid over engineering to get everything linguistically 100% accurate.
@@ -41,9 +38,11 @@ The opinionated *don't-over-split* stance coexists with several rules that *do* 
 Consider this example: `We make a good team, you and I. Did you see Albert I. Jones yesterday?`
 
 The accurate splitting of this sentence is
-`["We make a good team, you and I." ,"Did you see Albert I. Jones yesterday?"]`
+`["We make a good team, you and I.", "Did you see Albert I. Jones yesterday?"]`
 
 However, to achieve this level precision, complex rules need to be added and it could create side effects. Instead, if we just don't segment between `I. Did`, it is ok for most of downstream applications.
+
+List-item detection follows the same conservative posture. Ambiguous inline shapes that collide with prose (bare `1.` / `a.` / `ii.` closers inline, single-letter `a.` patterns that look like initials, parenthesised numbers like `(1894)` that read as years) deliberately do not trigger list segmentation. A sibling rule (≥2 matches of the same marker family per paragraph, or a single Tier-1 line-start) further suppresses one-off occurrences. The result: real lists segment per item, but prose containing list-shaped fragments stays intact.
 
 The sentence segmentation in this library is **non-destructive**. This means, if the sentences are combined together, you can reconstruct the original text. Line breaks, punctuations and whitespaces are preserved in the output.
 
@@ -218,7 +217,7 @@ Total sentences: 150254
 ```
 
 
-Measured on English Golden Rule Set (GRS) using mean F1 score across 60 test cases. List cases are excluded.
+Measured on English Golden Rule Set (GRS) using mean F1 score across 60 test cases.
 The benchmark script is at [`benchmarks/compare.py`](benchmarks/compare.py) and can be run with `uv run benchmarks/compare.py`.
 
 The following libraries are compared:

--- a/benches/segment_benchmark.rs
+++ b/benches/segment_benchmark.rs
@@ -151,6 +151,27 @@ fn bench_abbreviation_heavy_text(c: &mut Criterion) {
     });
 }
 
+fn bench_list_heavy_text(c: &mut Criterion) {
+    let text = "Here are the rules:\n\
+                * Be kind to others.\n\
+                * Be honest in your work.\n\
+                * Verify your assumptions.\n\n\
+                Numbered steps:\n\
+                1. Read the brief.\n\
+                2. Draft a response.\n\
+                3. Review and send.\n\n\
+                Lettered options:\n\
+                (a) First choice.\n\
+                (b) Second choice.\n\
+                (c) Third choice.\n\n\
+                • Unicode bullet item.\n\
+                • Another unicode bullet.";
+
+    c.bench_function("list_heavy_text", |b| {
+        b.iter(|| segment(black_box("en"), black_box(text)))
+    });
+}
+
 fn bench_quoted_text(c: &mut Criterion) {
     let text = r#"She said, "This is the first sentence." He replied, "This is the second one."
                   "What about this?" she asked. "And this!" he exclaimed."#;
@@ -203,6 +224,7 @@ criterion_group!(
     bench_multi_language,
     bench_paragraph_heavy_text,
     bench_abbreviation_heavy_text,
+    bench_list_heavy_text,
     bench_quoted_text,
     bench_quote_heavy_inner_terminators,
     bench_real_wikipedia_sample

--- a/src/languages/language.rs
+++ b/src/languages/language.rs
@@ -315,8 +315,8 @@ pub trait Language {
             // Detect list-item line starts once per paragraph and reuse the
             // result for both atomic-item ranges (so terminator-driven boundaries
             // inside an item are dropped) and explicit boundary emission below.
-            let list_starts = Some(super::list_markers::detect_list_items(paragraph)).unwrap_or_default();
-            
+            let list_starts = super::list_markers::detect_list_items(paragraph);
+
             if !list_starts.is_empty() {
                 for window in list_starts.windows(2) {
                     skippable_ranges.push(SkippableRange::new(

--- a/src/languages/language.rs
+++ b/src/languages/language.rs
@@ -176,6 +176,7 @@ pub enum SkippableRangeType {
     Quote,
     Parentheses,
     Email,
+    ListItem,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -309,7 +310,34 @@ pub trait Language {
                 .find_iter(paragraph)
                 .map(|m| (m.start(), m.end()))
                 .collect();
-            let skippable_ranges = self.get_skippable_ranges(paragraph);
+            let mut skippable_ranges = self.get_skippable_ranges(paragraph);
+
+            // Detect list-item line starts once per paragraph and reuse the
+            // result for both atomic-item ranges (so terminator-driven boundaries
+            // inside an item are dropped) and explicit boundary emission below.
+            let list_starts = Some(super::list_markers::detect_list_items(paragraph)).unwrap_or_default();
+            
+            if !list_starts.is_empty() {
+                for window in list_starts.windows(2) {
+                    skippable_ranges.push(SkippableRange::new(
+                        window[0],
+                        window[1],
+                        SkippableRangeType::ListItem,
+                    ));
+                }
+
+                let last = *list_starts.last().unwrap();
+
+                skippable_ranges.push(SkippableRange::new(
+                    last,
+                    paragraph.len(),
+                    SkippableRangeType::ListItem,
+                ));
+
+                // Consumers of skippable_ranges don't seem to rely on order, but I'm not sure if this is
+                // intentional or incidental.  If it's intentional, we can drop this sort.
+                skippable_ranges.sort_unstable_by_key(|r| r.start);
+            }
 
             'next_match: for (start, end) in matches {
                 let Some(mut boundary) = self.find_boundary(paragraph, start, end) else {
@@ -355,6 +383,21 @@ pub trait Language {
 
                 boundary = self.extend_past_orphan_closer(paragraph, boundary, &skippable_ranges);
                 push_if_increasing(&mut sentence_boundaries, boundary);
+            }
+
+            // Merge in list-item line starts as sentence boundaries. They may
+            // interleave with terminator boundaries in source order, so we
+            // sort + dedup once rather than maintain the increasing invariant
+            // during insertion.
+            if !list_starts.is_empty() {
+                for &start in &list_starts {
+                    if start > 0 {
+                        sentence_boundaries.push(start);
+                    }
+                }
+
+                sentence_boundaries.sort_unstable();
+                sentence_boundaries.dedup();
             }
 
             if *sentence_boundaries.last().unwrap() != paragraph.len() {

--- a/src/languages/list_markers.rs
+++ b/src/languages/list_markers.rs
@@ -1,0 +1,513 @@
+// List-item line/inline detector.
+//
+// Scans each paragraph once via memchr-driven line iteration, classifying
+// markers at both line starts and inline positions (after a whitespace run).
+// A "list = a sequence" sibling rule with a single winning family per paragraph
+// keeps false positives down. The caller uses the returned offsets to emit
+// sentence boundaries and to mark each item span as `SkippableRange::ListItem`.
+//
+// For performance reasons, char is used when unicode is unavoidable, and
+// byte parsing everywhere else.
+
+use strum::EnumCount;
+
+const UNICODE_BULLETS: &[char] = &[
+    '•', '◦', '▪', '▫', '■', '□', '●', '○', '⁃', '⁌', '⁍', '◆', '◇', '★', '☆', '➤', '➢', '➣', '▶',
+    '▸', '►',
+];
+
+/// Minimum byte distance between two same-family candidates before the
+/// second is kept. Real list items carry content between markers, so
+/// genuine siblings sit far apart; tightly-packed repeats are prose
+/// patterns (e.g. `e. e. cummings` - two `LetterDot` hits ~3 bytes apart).
+/// 4 is the smallest value that drops those while still admitting short
+/// real items like `1. x` (gap 4).
+const MIN_GAP_BYTES: usize = 4;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumCount)]
+enum MarkerFamily {
+    Tier1,       // unicode bullets, parenthesised forms — fire on a single line-start match
+    Bullet,      // * + - – —
+    Numeric,     // 1. 1) 1.) 23.
+    LetterParen, // a) A) a.) A.)
+    LetterDot,   // a. b. (lowercase only)
+    Roman,       // ii. iii) ii.) (≥2 chars, plus single-letter promoted via sibling rule)
+}
+
+impl MarkerFamily {
+    fn idx(self) -> usize {
+        self as usize
+    }
+
+    /// ASCII bullets (`*`, `+`, `-`) have no closing punctuation, so inline
+    /// they are indistinguishable from parenthetical or hyphen uses
+    /// ("Su - 24", "fast - track"). Two such uses would otherwise satisfy the
+    /// sibling rule and emit false boundaries. Line-start bullets go through
+    /// `classify_line` and are unaffected. Symmetric with the en/em-dash
+    /// exclusion in `match_ascii_bullet`.
+    fn allowed_inline(self) -> bool {
+        !matches!(self, MarkerFamily::Bullet)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Candidate {
+    pos: usize,
+    family: MarkerFamily,
+    first_byte: u8,
+    line_start: bool,
+}
+
+impl Candidate {
+    fn line_start(pos: usize, hit: MarkerHit) -> Self {
+        Self { pos, family: hit.family, first_byte: hit.first_byte, line_start: true }
+    }
+
+    fn inline(pos: usize, hit: MarkerHit) -> Self {
+        Self { pos, family: hit.family, first_byte: hit.first_byte, line_start: false }
+    }
+
+    /// A single-letter `a.`/`a)` candidate whose letter could read as Roman
+    /// (i, v, x, l, c, d, m). Used by `promote_roman_letters`.
+    fn is_roman_letter_shape(&self) -> bool {
+        matches!(self.family, MarkerFamily::LetterDot | MarkerFamily::LetterParen)
+            && is_roman_byte(self.first_byte)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MarkerHit {
+    family: MarkerFamily,
+    first_byte: u8,
+}
+
+/// Returns byte offsets (within `paragraph`) of accepted list-item starts,
+/// in source order with no duplicates.
+pub(crate) fn detect_list_items(paragraph: &str) -> Vec<usize> {
+    let bytes = paragraph.as_bytes();
+    let mut candidates: Vec<Candidate> = Vec::with_capacity((paragraph.len() / 50).max(1));
+    let mut line_start = 0usize;
+
+    for nl_pos in memchr::memchr_iter(b'\n', bytes) {
+        scan_line(paragraph, line_start, nl_pos + 1, &mut candidates);
+        line_start = nl_pos + 1;
+    }
+
+    if line_start < bytes.len() {
+        scan_line(paragraph, line_start, bytes.len(), &mut candidates);
+    }
+
+    finalise(candidates)
+}
+
+fn scan_line(text: &str, line_start: usize, line_end: usize, out: &mut Vec<Candidate>) {
+    let bytes = text.as_bytes();
+    let content_start = first_non_ws(bytes, line_start, line_end);
+
+    if let Some(hit) = classify_line(&text[content_start..line_end]) {
+        out.push(Candidate::line_start(line_start, hit));
+    }
+
+    // Each whitespace run is a candidate boundary; the byte after it may
+    // begin an inline list marker. memchr2 jumps between runs.
+    let mut cursor = content_start;
+    while let Some(rel) = memchr::memchr2(b' ', b'\t', &bytes[cursor..line_end]) {
+        let pos = first_non_ws(bytes, cursor + rel, line_end);
+        if pos >= line_end || matches!(bytes[pos], b'\n' | b'\r') {
+            break;
+        }
+
+        if let Some(hit) = classify_marker_at(&text[pos..line_end]) {
+            out.push(Candidate::inline(pos, hit));
+        }
+
+        cursor = pos;
+    }
+}
+
+/// Index of the first non-(space|tab) byte in `bytes[start..end]`, or `end`.
+fn first_non_ws(bytes: &[u8], start: usize, end: usize) -> usize {
+    let mut i = start;
+
+    while i < end && is_horiz_ws(bytes[i]) {
+        i += 1;
+    }
+    
+    i
+}
+
+/// Classify the start of a line (with leading indent already stripped).
+/// Requires a marker followed by at least one space and real content.
+fn classify_line(line: &str) -> Option<MarkerHit> {
+    let first_byte = *line.as_bytes().first()?;
+    let (family, len) = consume_marker(line)?;
+    next_content_char(&line[len..])?;
+    Some(MarkerHit { family, first_byte })
+}
+
+/// Classify a marker found inline (after a whitespace run). Stricter than
+/// `classify_line` because inline markers compete with prose punctuation.
+fn classify_marker_at(s: &str) -> Option<MarkerHit> {
+    let first_byte = *s.as_bytes().first()?;
+    let (family, len) = consume_marker(s)?;
+
+    if is_bare_dot_closer(s.as_bytes(), family, len) {
+        return None;
+    }
+
+    let next = next_content_char(&s[len..])?;
+    if next.is_lowercase() {
+        return None;
+    }
+
+    if !family.allowed_inline() {
+        return None;
+    }
+
+    Some(MarkerHit { family, first_byte })
+}
+
+/// Bare-dot closers (`1.`, `a.`, `ii.`) collide with sentence-ending periods
+/// in prose. Inline markers must use `)` or `.)`. Line-start markers are
+/// unaffected — the line break itself is the structural signal.
+fn is_bare_dot_closer(bytes: &[u8], family: MarkerFamily, marker_len: usize) -> bool {
+    bytes[marker_len - 1] == b'.'
+        && matches!(family, MarkerFamily::Numeric | MarkerFamily::LetterDot | MarkerFamily::Roman)
+}
+
+
+/// Returns the first non-space, non-tab character after `after_marker`, only
+/// if at least one space/tab is present and the resulting character is real
+/// content (not a line terminator).
+fn next_content_char(after_marker: &str) -> Option<char> {
+    let bytes = after_marker.as_bytes();
+    let n = first_non_ws(bytes, 0, bytes.len());
+    if n == 0 {
+        return None;
+    }
+
+    let c = after_marker[n..].chars().next()?;
+    (c != '\n' && c != '\r').then_some(c)
+}
+
+fn consume_marker(s: &str) -> Option<(MarkerFamily, usize)> {
+    // Order encodes priority. Tier 1 first; multi-char roman before single-letter
+    // `[a-z]\.` so `ii.` isn't classified as `LetterDot`.
+    None.or_else(|| match_unicode_bullet(s).map(|n| (MarkerFamily::Tier1, n)))
+        .or_else(|| match_paren_form(s).map(|n| (MarkerFamily::Tier1, n)))
+        .or_else(|| match_roman(s).map(|n| (MarkerFamily::Roman, n)))
+        .or_else(|| match_numeric(s).map(|n| (MarkerFamily::Numeric, n)))
+        .or_else(|| match_ascii_bullet(s).map(|n| (MarkerFamily::Bullet, n)))
+        .or_else(|| match_letter_paren(s).map(|n| (MarkerFamily::LetterParen, n)))
+        .or_else(|| match_letter_dot(s).map(|n| (MarkerFamily::LetterDot, n)))
+}
+
+fn match_unicode_bullet(s: &str) -> Option<usize> {
+    let c = s.chars().next()?;
+    UNICODE_BULLETS.contains(&c).then(|| c.len_utf8())
+}
+
+// En/em dashes (`–`/`—`) are intentionally NOT included: they collide with
+// parenthetical dashes in prose (e.g. Kazakh "(1905 — 11)") where the
+// sibling rule would falsely activate a list. Real `–`/`—` line-start
+// bullets are rare; users wanting them can use `*` or `-` instead.
+fn match_ascii_bullet(s: &str) -> Option<usize> {
+    match s.as_bytes().first()? {
+        b'*' | b'+' | b'-' => Some(1),
+        _ => None,
+    }
+}
+
+fn match_numeric(s: &str) -> Option<usize> {
+    let b = s.as_bytes();
+    let n = b.iter().take_while(|c| c.is_ascii_digit()).count();
+    if n == 0 {
+        return None;
+    }
+
+    closer_len_at(b, n).map(|cl| n + cl)
+}
+
+fn match_roman(s: &str) -> Option<usize> {
+    let b = s.as_bytes();
+    let n = b.iter().take_while(|&&c| is_roman_byte(c)).count();
+    if n < 2 {
+        return None;
+    }
+
+    closer_len_at(b, n).map(|cl| n + cl)
+}
+
+// Accepts `a)` and `a.)` but not `a.` alone (that's LetterDot's territory).
+fn match_letter_paren(s: &str) -> Option<usize> {
+    let b = s.as_bytes();
+    if b.len() < 2 || !b[0].is_ascii_alphabetic() {
+        return None;
+    }
+
+    match b[1] {
+        b')' => Some(2),
+        b'.' if b.get(2) == Some(&b')') => Some(3),
+        _ => None,
+    }
+}
+
+fn match_letter_dot(s: &str) -> Option<usize> {
+    let b = s.as_bytes();
+    (b.len() >= 2 && b[0].is_ascii_lowercase() && b[1] == b'.').then_some(2)
+}
+
+// (1), (12), (a), (A), (ii), (iv) — short, unpadded inners only.
+// Padded inners (`( 1894 )`) and 3+ digit inners (`(1894)`) are prose
+// year/date citations, not list markers.
+fn match_paren_form(s: &str) -> Option<usize> {
+    let inside = s.strip_prefix('(')?;
+    let close = inside.find(')')?;
+    let inner = inside[..close].as_bytes();
+
+    let short_numeric = (1..=2).contains(&inner.len()) && inner.iter().all(|b| b.is_ascii_digit());
+    let single_letter = inner.len() == 1 && inner[0].is_ascii_alphabetic();
+    let roman = !inner.is_empty() && inner.iter().all(|&b| is_roman_byte(b));
+
+    (short_numeric || single_letter || roman).then_some(close + 2)
+}
+
+/// Length of marker closer at byte position `pos` — `.`, `)`, or `.)`.
+fn closer_len_at(b: &[u8], pos: usize) -> Option<usize> {
+    match b.get(pos)? {
+        b'.' if b.get(pos + 1) == Some(&b')') => Some(2),
+        b'.' | b')' => Some(1),
+        _ => None,
+    }
+}
+
+fn is_horiz_ws(b: u8) -> bool {
+    b == b' ' || b == b'\t'
+}
+
+fn is_roman_byte(b: u8) -> bool {
+    matches!(
+        b.to_ascii_lowercase(),
+        b'i' | b'v' | b'x' | b'l' | b'c' | b'd' | b'm'
+    )
+}
+
+fn finalise(mut candidates: Vec<Candidate>) -> Vec<usize> {
+    if candidates.is_empty() {
+        return Vec::new();
+    }
+
+    sort_and_dedup(&mut candidates);
+    promote_roman_letters(&mut candidates);
+    gap_prune_per_family(&mut candidates);
+
+    let Some(winner) = pick_winner(&candidates) else {
+        return Vec::new();
+    };
+
+    candidates
+        .into_iter()
+        .filter(|c| c.family == winner)
+        .map(|c| c.pos)
+        .collect()
+}
+
+/// Sort by position; on ties (rare; degenerate inputs only) prefer line-start.
+/// `!line_start` gives `false < true`, so `true` sorts first.
+fn sort_and_dedup(candidates: &mut Vec<Candidate>) {
+    candidates.sort_by_key(|c| (c.pos, !c.line_start));
+    candidates.dedup_by_key(|c| c.pos);
+}
+
+/// If any multi-char Roman exists, reclassify single-letter roman-shaped
+/// LetterDot/LetterParen candidates as Roman so they count as siblings
+/// (handles `i.) ... ii.)`).
+fn promote_roman_letters(candidates: &mut [Candidate]) {
+    if !candidates.iter().any(|c| c.family == MarkerFamily::Roman) {
+        return;
+    }
+
+    for c in candidates {
+        if c.is_roman_letter_shape() {
+            c.family = MarkerFamily::Roman;
+        }
+    }
+}
+
+/// Drop candidates too close to the previous match *of the same family*.
+/// A real list item carries content; `e. e. cummings` (LetterDot gap 3) does
+/// not. Run BEFORE family selection so sibling counts reflect the pruned set.
+fn gap_prune_per_family(candidates: &mut Vec<Candidate>) {
+    let mut family_last = [usize::MAX; MarkerFamily::COUNT];
+
+    candidates.retain(|c| {
+        let last = family_last[c.family.idx()];
+        let keep = last == usize::MAX || c.pos - last >= MIN_GAP_BYTES;
+
+        if keep {
+            family_last[c.family.idx()] = c.pos;
+        }
+
+        keep
+    });
+}
+
+/// Choose the winning family for the paragraph, or `None` for "no list".
+///
+/// Tier 1 (unicode bullets, parenthesised forms) wins on a single line-start
+/// match or two matches anywhere. Otherwise the Tier 2 family with the most
+/// matches wins, with the earliest first match breaking ties.
+fn pick_winner(candidates: &[Candidate]) -> Option<MarkerFamily> {
+    let mut counts = [0u32; MarkerFamily::COUNT];
+    let mut first_pos = [usize::MAX; MarkerFamily::COUNT];
+    let mut tier1_at_line_start = false;
+
+    for c in candidates {
+        let i = c.family.idx();
+        counts[i] += 1;
+        if first_pos[i] == usize::MAX {
+            first_pos[i] = c.pos;
+        }
+
+        if c.family == MarkerFamily::Tier1 && c.line_start {
+            tier1_at_line_start = true;
+        }
+    }
+
+    if tier1_at_line_start || counts[MarkerFamily::Tier1.idx()] >= 2 {
+        return Some(MarkerFamily::Tier1);
+    }
+
+    const TIER2: &[MarkerFamily] = &[
+        MarkerFamily::Bullet,
+        MarkerFamily::Numeric,
+        MarkerFamily::LetterParen,
+        MarkerFamily::LetterDot,
+        MarkerFamily::Roman,
+    ];
+
+    TIER2.iter()
+        .copied()
+        .filter(|&f| counts[f.idx()] >= 2)
+        .max_by_key(|&f| (counts[f.idx()], std::cmp::Reverse(first_pos[f.idx()])))
+}
+
+#[cfg(test)]
+mod fixture {
+    use crate::languages::English;
+    use crate::languages::tests::run_language_tests;
+
+    #[test]
+    fn segments_lists() {
+        run_language_tests(English {}, "tests/lists.txt");
+    }
+}
+
+// Unit tests here cover detector-internal policy that the end-to-end fixture
+// in `tests/lists.txt` cannot distinguish: cases where the detector must
+// return an empty result (so the segmenter falls back to terminator-driven
+// segmentation) and cases that test which family wins. Positive line-start /
+// inline-paren shapes belong in `tests/lists.txt`.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn detect(s: &str) -> Vec<usize> {
+        detect_list_items(s)
+    }
+
+    // Detector-must-be-silent cases. Lists.txt sees the post-pipeline
+    // segments, which can match terminator-driven output even if the detector
+    // wrongly fires; these assert the detector itself returns nothing.
+
+    #[test]
+    fn inline_numeric_dot_only_not_handled() {
+        // Bare-dot closer inline is ambiguous with a wrapped prose sentence
+        // ending in `...Foo 1.`.
+        let starts = detect("1. The first item. 2. The second item.");
+        assert!(starts.is_empty(), "got {starts:?}");
+    }
+
+    #[test]
+    fn inline_letter_dot_not_handled() {
+        // Bare-dot closer + lowercase letter collides with initials
+        // (e. e. cummings) and date/abbrev shapes.
+        let starts = detect("a. The first item b. The second item");
+        assert!(starts.is_empty(), "got {starts:?}");
+    }
+
+    #[test]
+    fn inline_roman_dot_not_handled() {
+        let starts = detect("ii. The first item iii. The second item");
+        assert!(starts.is_empty(), "got {starts:?}");
+    }
+
+    #[test]
+    fn inline_year_parens_not_a_list() {
+        let s = "Examples include 'Sonar Tari' ( 1894 ), 'Chitra' ( 1896 ), \
+                 and 'Katha O Kahini' ( 1900 ).";
+        assert!(detect(s).is_empty(), "got {:?}", detect(s));
+        let s2 = "Works (1894), (1896), and (1900) are notable.";
+        assert!(detect(s2).is_empty(), "got {:?}", detect(s2));
+    }
+
+    #[test]
+    fn ee_cummings_no_segmentation() {
+        // `e. e.` has zero non-marker content between markers → gap pruning
+        // drops the second, leaving fewer than 2 siblings.
+        let starts = detect("From\ne. e. cummings, with love.");
+        assert!(starts.is_empty(), "got {starts:?}");
+    }
+
+    #[test]
+    fn uppercase_letter_dot_excluded() {
+        let starts = detect("Reviewed by\nA. Smith and\nB. Jones.");
+        assert!(starts.is_empty(), "got {starts:?}");
+    }
+
+    #[test]
+    fn lone_lowercase_letter_dot_no_siblings() {
+        let starts = detect("The answer is a.\nFollow up later.");
+        assert!(starts.is_empty(), "got {starts:?}");
+    }
+
+    #[test]
+    fn lone_numeric_after_wrap() {
+        let starts = detect("The total was\n1. Two hundred dollars exactly.");
+        assert!(starts.is_empty(), "got {starts:?}");
+    }
+
+    #[test]
+    fn eg_at_line_start() {
+        let starts = detect("e.g. one\ne.g. two\n");
+        assert!(starts.is_empty(), "got {starts:?}");
+    }
+
+    #[test]
+    fn marker_only_lines() {
+        let starts = detect("*\n*\n*\n");
+        assert!(starts.is_empty(), "got {starts:?}");
+    }
+
+    #[test]
+    fn no_markers_plain_prose() {
+        let starts = detect("Hello world. This is a test. Three sentences here.");
+        assert!(starts.is_empty(), "got {starts:?}");
+    }
+
+    #[test]
+    fn empty_paragraph() {
+        let starts = detect("");
+        assert!(starts.is_empty(), "got {starts:?}");
+    }
+
+    // Family-selection case: bullets must win over numeric decoration.
+    #[test]
+    fn inline_unicode_bullet_with_decoration() {
+        let s = "• 9. The first item • 10. The second item";
+        let starts = detect(s);
+        assert_eq!(starts.len(), 2);
+        assert_eq!(starts[0], 0);
+        assert_eq!(&s[starts[1]..starts[1] + 3], "•");
+    }
+}

--- a/src/languages/list_markers.rs
+++ b/src/languages/list_markers.rs
@@ -60,18 +60,30 @@ struct Candidate {
 
 impl Candidate {
     fn line_start(pos: usize, hit: MarkerHit) -> Self {
-        Self { pos, family: hit.family, first_byte: hit.first_byte, line_start: true }
+        Self {
+            pos,
+            family: hit.family,
+            first_byte: hit.first_byte,
+            line_start: true,
+        }
     }
 
     fn inline(pos: usize, hit: MarkerHit) -> Self {
-        Self { pos, family: hit.family, first_byte: hit.first_byte, line_start: false }
+        Self {
+            pos,
+            family: hit.family,
+            first_byte: hit.first_byte,
+            line_start: false,
+        }
     }
 
     /// A single-letter `a.`/`a)` candidate whose letter could read as Roman
     /// (i, v, x, l, c, d, m). Used by `promote_roman_letters`.
     fn is_roman_letter_shape(&self) -> bool {
-        matches!(self.family, MarkerFamily::LetterDot | MarkerFamily::LetterParen)
-            && is_roman_byte(self.first_byte)
+        matches!(
+            self.family,
+            MarkerFamily::LetterDot | MarkerFamily::LetterParen
+        ) && is_roman_byte(self.first_byte)
     }
 }
 
@@ -132,7 +144,7 @@ fn first_non_ws(bytes: &[u8], start: usize, end: usize) -> usize {
     while i < end && is_horiz_ws(bytes[i]) {
         i += 1;
     }
-    
+
     i
 }
 
@@ -172,9 +184,11 @@ fn classify_marker_at(s: &str) -> Option<MarkerHit> {
 /// unaffected — the line break itself is the structural signal.
 fn is_bare_dot_closer(bytes: &[u8], family: MarkerFamily, marker_len: usize) -> bool {
     bytes[marker_len - 1] == b'.'
-        && matches!(family, MarkerFamily::Numeric | MarkerFamily::LetterDot | MarkerFamily::Roman)
+        && matches!(
+            family,
+            MarkerFamily::Numeric | MarkerFamily::LetterDot | MarkerFamily::Roman
+        )
 }
-
 
 /// Returns the first non-space, non-tab character after `after_marker`, only
 /// if at least one space/tab is present and the resulting character is real
@@ -263,7 +277,9 @@ fn match_letter_dot(s: &str) -> Option<usize> {
 fn match_paren_form(s: &str) -> Option<usize> {
     let inside = s.strip_prefix('(')?;
     let close = inside.find(')')?;
-    let inner = inside[..close].as_bytes();
+
+    // Safe since close lands on a valid utf8 boundary
+    let inner = &inside.as_bytes()[..close];
 
     let short_numeric = (1..=2).contains(&inner.len()) && inner.iter().all(|b| b.is_ascii_digit());
     let single_letter = inner.len() == 1 && inner[0].is_ascii_alphabetic();
@@ -386,7 +402,8 @@ fn pick_winner(candidates: &[Candidate]) -> Option<MarkerFamily> {
         MarkerFamily::Roman,
     ];
 
-    TIER2.iter()
+    TIER2
+        .iter()
         .copied()
         .filter(|&f| counts[f.idx()] >= 2)
         .max_by_key(|&f| (counts[f.idx()], std::cmp::Reverse(first_pos[f.idx()])))

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -117,7 +117,7 @@ mod tests {
                 .collect();
 
             let result = language.segment(&input);
-            
+
             let actual: Vec<String> = result
                 .iter()
                 .map(|item| normalise(item))

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -19,6 +19,7 @@ mod ja;
 mod kk;
 mod kn;
 mod language;
+mod list_markers;
 mod ml;
 mod mr;
 mod my;
@@ -73,36 +74,57 @@ mod tests {
     use super::*;
 
     pub fn run_language_tests<T: Language>(language: T, test_file: &str) {
-        let content = fs::read_to_string(test_file).expect("Failed to read test file");
-        // Split on the bare delimiters (no trailing `\n`) so CRLF-checkout files
-        // on Windows parse identically to LF files on Linux/macOS.
+        let raw = fs::read_to_string(test_file).expect("Failed to read test file");
+        let content = raw.replace("\r\n", "\n");
         let test_cases: Vec<&str> = content.split("===").collect();
 
         for case in test_cases {
-            let case = case.trim();
-            if case.is_empty() || case.starts_with('#') {
+            // Explicit '#' comment handling. This lets fixture files include
+            // section headers and structural comments anywhere — not just at
+            // the very top of the file — without silently skipping cases that
+            // happen to share a chunk with leading comments.
+            let cleaned: String = case
+                .lines()
+                .filter(|line| !line.trim_start().starts_with('#'))
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            let cleaned = cleaned.trim();
+            if cleaned.is_empty() {
                 continue;
             }
-            let parts: Vec<&str> = case
+
+            let parts: Vec<&str> = cleaned
                 .split("---")
                 .map(|part| part.trim())
                 .filter(|part| !part.is_empty())
                 .collect();
+
             if parts.len() != 2 {
                 continue; // Skip malformed test cases
             }
 
+            // Comparison normalises whitespace on both sides — any run of
+            // whitespace (spaces, tabs, newlines) collapses to a single
+            // space.
+            let normalise = |s: &str| s.split_whitespace().collect::<Vec<_>>().join(" ");
             let input = parts[0];
-            let expected: Vec<&str> = parts[1]
-                .lines()
-                .map(|line| line.trim())
-                .filter(|line| !line.is_empty())
-                .collect();
-            let result = language.segment(input);
-            let trimmed_result: Vec<String> =
-                result.iter().map(|item| item.trim().to_string()).collect();
 
-            assert_eq!(trimmed_result, expected, "Failed for input: \n{}", input);
+            let expected: Vec<String> = parts[1]
+                .lines()
+                .map(|s| normalise(&s))
+                .filter(|s| !s.is_empty())
+                .collect();
+
+            let result = language.segment(&input);
+            
+            let actual: Vec<String> = result
+                .iter()
+                .map(|item| normalise(item))
+                .filter(|s| !s.is_empty())
+                .collect();
+
+            assert_eq!(actual, expected, "Failed for input: \n{}", input);
         }
     }
 }

--- a/tests/lists.txt
+++ b/tests/lists.txt
@@ -1,0 +1,178 @@
+# List-item / enumeration test fixtures.
+# Each test case is defined as:
+# Input text
+# ---
+# Expected segments (one per line, trimmed)
+# ===
+#
+# Each expected segment is one non-empty line. Use `\n` (literal backslash-n)
+# inside an expected line to embed a real newline - necessary when a single
+# segment spans multiple lines of input (line-wrapped prose without a
+# paragraph break stays as one segment, with the original `\n` preserved).
+
+# --------------------------------------------------------------------
+# accepts: list shapes that segment as one sentence per item.
+# --------------------------------------------------------------------
+Multi line sentence
+We should not split this as a sanity check
+---
+Multi line sentence We should not split this as a sanity check
+===
+* apples
+* oranges
+* bananas
+---
+* apples
+* oranges
+* bananas
+===
+• apples
+• oranges
+---
+• apples
+• oranges
+===
+a) foo
+b) bar
+---
+a) foo
+b) bar
+===
+(a) only one item here
+---
+(a) only one item here
+===
+(1) foo
+(2) bar
+---
+(1) foo
+(2) bar
+===
+* The report is final. Send it tomorrow.
+* Verify with QA.
+---
+* The report is final. Send it tomorrow.
+* Verify with QA.
+===
+Here are the rules:
+* Be kind.
+* Be honest.
+---
+Here are the rules:
+* Be kind.
+* Be honest.
+===
+ii. First
+iii. Second
+---
+ii. First
+iii. Second
+===
+a. apples
+b. oranges
+c. bananas
+---
+a. apples
+b. oranges
+c. bananas
+===
+1. apples
+2. oranges
+---
+1. apples
+2. oranges
+===
+
+# Indentation note: the harness trims the leading whitespace of the whole
+# case block, so line 1's indent is stripped here. Line 2's indent is
+# preserved and still exercises the indented-bullet path.
+* indented
+   * also indented
+---
+* indented
+* also indented
+===
+
+# --------------------------------------------------------------------
+# inline: enumerations on a single line.
+# --------------------------------------------------------------------
+
+1.) The first item. 2.) The second item.
+---
+1.) The first item.
+2.) The second item.
+===
+1) The first item 2) The second item
+---
+1) The first item
+2) The second item
+===
+• 9. The first item • 10. The second item
+---
+• 9. The first item
+• 10. The second item
+===
+a.) The first item b.) The second item
+---
+a.) The first item
+b.) The second item
+===
+a) The first item b) The second item
+---
+a) The first item
+b) The second item
+===
+i.) The first item ii.) The second item
+---
+i.) The first item
+ii.) The second item
+===
+
+# --------------------------------------------------------------------
+# deliberately not handled. Scanner must not fire here.
+# Snapshot the pre-existing terminator-driven behaviour so any future drift
+# surfaces as a deliberate decision.
+# --------------------------------------------------------------------
+
+1. The first item. 2. The second item.
+---
+1.
+The first item.
+2.
+The second item.
+===
+a. The first item b. The second item
+---
+a. The first item b. The second item
+===
+ii. The first item iii. The second item
+---
+ii.
+The first item iii.
+The second item
+===
+(1). foo
+(2). bar
+---
+(1).
+foo (2).
+bar
+===
+I. went home today.
+---
+I. went home today.
+===
+On 4 October 1999 , a Su - 24 was shot down by a SAM while searching for the crash site of a downed Su - 25 .
+---
+On 4 October 1999 , a Su - 24 was shot down by a SAM while searching for the crash site of a downed Su - 25 .
+===
+Examples include '' Sonar Tari '' ( 1894 ) , '' Chitra '' ( 1896 ) , and '' Katha O Kahini '' (1900). His essays , poems , and plays of the time also touched on village life .
+---
+Examples include '' Sonar Tari '' ( 1894 ) , '' Chitra '' ( 1896 ) , and '' Katha O Kahini '' (1900).
+His essays , poems , and plays of the time also touched on village life .
+===
+In his first professional season , he led the Gulf Coast League in doubles (20), and ranked third in extra-base hits ( 22 ) . He posted a 5 for 5 game with five doubles , three runs scored and three RBI 's on July 17 , 2003 at GCL Twins .
+---
+In his first professional season , he led the Gulf Coast League in doubles (20), and ranked third in extra-base hits ( 22 ) .
+He posted a 5 for 5 game with five doubles , three runs scored and three RBI 's on July 17 , 2003 at GCL Twins .
+===

--- a/tests/lists.txt
+++ b/tests/lists.txt
@@ -5,10 +5,9 @@
 # Expected segments (one per line, trimmed)
 # ===
 #
-# Each expected segment is one non-empty line. Use `\n` (literal backslash-n)
-# inside an expected line to embed a real newline - necessary when a single
-# segment spans multiple lines of input (line-wrapped prose without a
-# paragraph break stays as one segment, with the original `\n` preserved).
+# Each expected segment is one non-empty line. Use `\n` (literal backslash-n) inside an expected line to embed a real newline
+# - necessary when a single segment spans multiple lines of input (line-wrapped prose without a paragraph break stays as one
+# segment, with the original `\n` preserved).
 
 # --------------------------------------------------------------------
 # accepts: list shapes that segment as one sentence per item.
@@ -129,9 +128,8 @@ ii.) The second item
 ===
 
 # --------------------------------------------------------------------
-# deliberately not handled. Scanner must not fire here.
-# Snapshot the pre-existing terminator-driven behaviour so any future drift
-# surfaces as a deliberate decision.
+# Deliberately not handled. Scanner must not fire here.
+# Snapshot the pre-existing terminator-driven behaviour so any future drift surfaces as a deliberate decision.
 # --------------------------------------------------------------------
 
 1. The first item. 2. The second item.


### PR DESCRIPTION
Add targeted list and enumeration boundaries.

* Adds opt-in list-item segmentation so that some ASCII and unicode bullets, e.g., (*, +, -, •), numeric markers (1., 1), (1)), lettered markers (a), (a)), and Roman numerals (ii.) emit sentence boundaries - both on their own lines and inline. A sibling rule (≥2 matches of the same marker family per paragraph, or a single Tier-1 line-start) keeps prose containing stray fragments like (1894) or e. e. cummings from being mis-split.
* Bare (i.e., not a marker family) 1. / a. / ii. closers, single-letter a. initials, parenthesised years) deliberately do not trigger list segmentation to prevent over-splitting in prose or citations.
* Do-not-trigger cases are codified in the `lists.txt` test data so any additional future coverage changes are forced to be explicit.

* It uses `memchr` (can take advantage of SIMD) in the parsing loop instead of `split_inclusive` since testing showed measurable performance gains.
* Test harness adds support for multi line inputs.
 a. Explicit white space trimming
 b. `\r\n` folding (just in case)
 c. Explicit comment `#` handling.

* Test cases and benchmarks added
* README updated

This focuses mostly on carving out cases for English/Latin family of languages.  Properly supporting other language markers is perhaps a discussion for another time since it might involve:
* Recognising numeric symbols in other scripts, e.g., `二` instead of `2`.
* Allowing for non ASCII list marker closers, e.g., instead of `1.` it could be something like `1。`
* Probably other issues I'm currently unaware of.