### PR TITLE
Multi punctuation run

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Besides native Rust, bindings for the following programming languages are availa
 - A sentence-terminating punctuation mark (`.`, `?`, `!`, plus language specific terminators like `।` or `။`) ends a sentence by default. Some languages use different terminators so a list of known terminator symbols is maintained for supported languages.
 - Hand-compiled abbreviation lists, exclamation words, numbered references (`See [1]. Next sentence.`), and quote-aware rules (see below) suppress or relocate boundaries where the default rule would over-split. We collect a list of known, popular abbreviations in supported languages.
 - List-item starts (e.g., bullets `*` / `+` / `-` / `•`, numeric `1.` / `1)` / `(1)`, lettered `a)` / `(a)`, roman `ii.`) emit sentence boundaries so each item segments cleanly, even when items are written inline on one line. A sibling rule (≥2 matches of the same marker family per paragraph, or a single Tier-1 line-start) keeps prose with stray `(1894)` or `e. e. cummings` from being mis-split.
+- Multi-character punctuation runs (`. . .`, `! ?`, `? ? ?`, glued or space-separated) are treated as a single terminator. This generalises the ellipsis (`…` / `...`) case: any mix of `.`, `!`, `?` - repeated, spaced, or interleaved - collapses into one boundary candidate instead of several. Continuation heuristics then decide whether the following token starts a new sentence: uppercase non-`I` splits, while lowercase, digits, or glued continuations (e.g. `mean...see`) keep the sentence intact.
 
 Sometimes, it is very hard to get the segmentation correct. In such cases this library is opinionated and prefer not segmenting than wrong segmentation. If two sentences are accidentally together, that is ok. It is better than sentence being split in middle.
 Avoid over engineering to get everything linguistically 100% accurate.
@@ -43,6 +44,12 @@ The accurate splitting of this sentence is
 However, to achieve this level precision, complex rules need to be added and it could create side effects. Instead, if we just don't segment between `I. Did`, it is ok for most of downstream applications.
 
 List-item detection follows the same conservative posture. Ambiguous inline shapes that collide with prose (bare `1.` / `a.` / `ii.` closers inline, single-letter `a.` patterns that look like initials, parenthesised numbers like `(1894)` that read as years) deliberately do not trigger list segmentation. A sibling rule (≥2 matches of the same marker family per paragraph, or a single Tier-1 line-start) further suppresses one-off occurrences. The result: real lists segment per item, but prose containing list-shaped fragments stays intact.
+
+Several other small heuristics follow the same "recover when the signal is clear, otherwise leave it joined" posture:
+
+- **Stray punctuation around terminators**: a period immediately followed by a comma (`…ice cream. , It was…`) is treated as stray punctuation and the sentence continues through it. Whitespace between an abbreviation and its terminator (`U.S .`) is tolerated when looking up the abbreviation, so the boundary is still suppressed.
+- **Dot-coded tokens like chess notation**: tokens of the shape `<digit>.<letter…>` (e.g. `7.Bg5`, `1.e4`) do not emit a boundary, so move codes and similar dot-coded identifiers stay inside their sentence.
+- **Slash-joined abbreviations**: tokens like `171/U.S.` are split on `/` when extracting the trailing word, so the abbreviation on the right-hand side is still recognised.
 
 The sentence segmentation in this library is **non-destructive**. This means, if the sentences are combined together, you can reconstruct the original text. Line breaks, punctuations and whitespaces are preserved in the output.
 

--- a/src/languages/en.rs
+++ b/src/languages/en.rs
@@ -1,4 +1,5 @@
 use super::Language;
+use regex::Regex;
 use std::sync::LazyLock;
 
 #[derive(Debug, Clone)]
@@ -12,9 +13,19 @@ static ENGLISH_ABBREVIATIONS: LazyLock<Vec<String>> = LazyLock::new(|| {
         .collect()
 });
 
+// English `I` is the one capital that case cannot distinguish from a sentence
+// start, so after an ellipsis run `... I'm` reads as continuation.
+static ENGLISH_ELLIPSIS_I_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s+I(?:[\s'\u{2019}]|$)").unwrap());
+
 impl Language for English {
     fn get_abbreviations(&self) -> &[String] {
         &ENGLISH_ABBREVIATIONS
+    }
+
+    fn is_ellipsis_continuation(&self, text_after_run: &str) -> bool {
+        super::language::ELLIPSIS_CONTINUE_REGEX.is_match(text_after_run)
+            || ENGLISH_ELLIPSIS_I_REGEX.is_match(text_after_run)
     }
 }
 

--- a/src/languages/language.rs
+++ b/src/languages/language.rs
@@ -836,6 +836,23 @@ pub trait Language {
             return None;
         }
 
+        // Digit immediately before the period and a digit-bearing alphanumeric
+        // token immediately after (no space) is a code-like numbered token,
+        // not a sentence end: chess moves (`7.Bg5`). Requiring a digit in the
+        // follower keeps quantities like `1,000.That` on the normal boundary
+        // path. The lowercase variant (`7.f4`) already passes through
+        // `continues`; this handles the uppercase case.
+        if matched == "."
+            && head.bytes().next_back().is_some_and(|b| b.is_ascii_digit())
+            && next_word_approx
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_alphabetic())
+            && next_word_approx.bytes().any(|b| b.is_ascii_digit())
+        {
+            return None;
+        }
+
         if self.is_abbreviation(head, next_word_approx, &text[start..end]) {
             return None;
         }

--- a/src/languages/language.rs
+++ b/src/languages/language.rs
@@ -37,13 +37,12 @@ static CONTINUE_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[0-9a-z]
 static CONTINUE_AFTER_NONWORD_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^\W*[0-9a-z]").unwrap());
 
-// Continuation rule for ellipsis matches: treat the run as mid-sentence when
-// the follow-up is whitespace + a lowercase/digit (`... no`, `. . . what`) or
-// whitespace + a standalone `I` (`... I'm`, `. . . I didn't`). `I` is the one
-// capital that can't be distinguished from a sentence start by case, so it's
-// folded in as continuation; `No`, `Then`, `And` still mark a boundary.
-static ELLIPSIS_CONTINUE_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^\s+(?:[0-9a-z]|I(?:[\s'\u{2019}]|$))").unwrap());
+// Ellipsis continuation: treat a multi-char terminator run as mid-sentence when the follow-up is
+// whitespace + a lowercase letter or digit (`... no`, `. . . what`). Languages with a
+// capitalized word that is ambiguous with a sentence start (English standalone `I`) extend
+// this via the `is_ellipsis_continuation` trait method.
+pub(crate) static ELLIPSIS_CONTINUE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s+[0-9a-z]").unwrap());
 
 // Glued lowercase after an ellipsis (`mean...see`) is intra-utterance hesitation
 // and continues the sentence. Only fires when the dots are also glued behind -
@@ -694,7 +693,7 @@ pub trait Language {
         is_abbrev || is_abbrev_lower || is_abbrev_upper
     }
 
-    /// Extracts the last word from the given text by splitting on whitespace and periods.
+    /// Extracts the last word from the given text by splitting on whitespace, periods, and slashes.
     /// Used primarily by abbreviation detection to check if the word before a potential
     /// sentence boundary is a known abbreviation. Returns an empty string if no words
     /// are found. This is a performance-optimized version that avoids collecting all words.
@@ -702,17 +701,11 @@ pub trait Language {
         // Trim trailing whitespace so a stray space before the terminator
         // (`U.S .`) doesn't blank out the last word. `/` joins route names
         // to abbreviations (`171/U.S`) without being a real word boundary,
-        // so split on it too. Walk back from the end (rfind) rather than
-        // splitting from the start: this is on the per-match hot path and
-        // we only need the trailing word.
-        let trimmed = text.trim_end();
-        match trimmed
-            .char_indices()
-            .rfind(|(_, c)| c.is_whitespace() || *c == '.' || *c == '/')
-        {
-            Some((i, c)) => &trimmed[i + c.len_utf8()..],
-            None => trimmed,
-        }
+        // so split on it too.
+        text.trim_end()
+            .split(|c: char| c.is_whitespace() || c == '.' || c == '/')
+            .next_back()
+            .expect("str::split always yields at least one element")
     }
 
     /// Checks if a potential sentence boundary is actually an exclamation word that shouldn't
@@ -800,21 +793,10 @@ pub trait Language {
         let head = &text[..start];
         let matched = &text[start..end];
 
-        // Any coalesced multi-char terminator run (`...`, `!?`, `. . .`, `! ?`)
-        // allows leading whitespace before the lowercase continuation test, so
-        // `! ? is` and `... no` read as mid-sentence. `chars().nth(1)` rules out
-        // a single multi-byte terminator (`。`, `…`), which would otherwise look
-        // multi-char by byte length.
-        let is_multi_char_run = matched.chars().nth(1).is_some();
-
-        // For any multi-char match (e.g. `...`, `!?`, `!...`), scan continuation
-        // and trailing-space extension from the end of the run, not from one byte
-        // past its first char.
-        let next_index = if is_multi_char_run {
-            end
-        } else {
-            text.ceil_char_boundary(start + 1)
-        };
+        // Scan continuation and trailing-space extension from the end of the
+        // matched terminator. For a single-char match `end` is one-past the
+        // terminator char; for a coalesced run it's the end of the whole run.
+        let next_index = end;
 
         let next_word_approx = self.get_next_word_approx(text, next_index);
 
@@ -824,8 +806,15 @@ pub trait Language {
             return Some(next_index + number_ref_match.end());
         }
 
+        // Any coalesced multi-char terminator run (`...`, `!?`, `. . .`, `! ?`)
+        // allows leading whitespace before the lowercase continuation test, so
+        // `! ? is` and `... no` read as mid-sentence. `chars().nth(1)` rules out
+        // a single multi-byte terminator (`。`, `…`), which would otherwise look
+        // multi-char by byte length.
+        let is_multi_char_run = matched.chars().nth(1).is_some();
+
         let continues = if is_multi_char_run {
-            ELLIPSIS_CONTINUE_REGEX.is_match(next_word_approx)
+            self.is_ellipsis_continuation(next_word_approx)
                 || (head.chars().next_back().is_some_and(|c| !c.is_whitespace())
                     && ELLIPSIS_GLUED_CONTINUE_REGEX.is_match(next_word_approx))
         } else {
@@ -868,6 +857,14 @@ pub trait Language {
         }
 
         Some(end)
+    }
+
+    /// True when text following a multi-char terminator run (`...`, `! ?`,
+    /// `. . .`) continues the current sentence rather than starting a new one.
+    /// The default treats only whitespace + a lowercase letter/digit as
+    /// continuation.
+    fn is_ellipsis_continuation(&self, text_after_run: &str) -> bool {
+        ELLIPSIS_CONTINUE_REGEX.is_match(text_after_run)
     }
 
     /// Determines if the text after a potential boundary indicates the sentence should continue.

--- a/src/languages/language.rs
+++ b/src/languages/language.rs
@@ -636,10 +636,20 @@ pub trait Language {
     /// sentence boundary is a known abbreviation. Returns an empty string if no words
     /// are found. This is a performance-optimized version that avoids collecting all words.
     fn get_last_word<'a>(&self, text: &'a str) -> &'a str {
-        // Find the last word without collecting all words
-        text.split(|c: char| c.is_whitespace() || c == '.')
-            .next_back()
-            .unwrap_or("")
+        // Trim trailing whitespace so a stray space before the terminator
+        // (`U.S .`) doesn't blank out the last word. `/` joins route names
+        // to abbreviations (`171/U.S`) without being a real word boundary,
+        // so split on it too. Walk back from the end (rfind) rather than
+        // splitting from the start: this is on the per-match hot path and
+        // we only need the trailing word.
+        let trimmed = text.trim_end();
+        match trimmed
+            .char_indices()
+            .rfind(|(_, c)| c.is_whitespace() || *c == '.' || *c == '/')
+        {
+            Some((i, c)) => &trimmed[i + c.len_utf8()..],
+            None => trimmed,
+        }
     }
 
     /// Checks if a potential sentence boundary is actually an exclamation word that shouldn't

--- a/src/languages/language.rs
+++ b/src/languages/language.rs
@@ -12,7 +12,20 @@ use crate::constants::QUOTES_REGEX;
 use crate::constants::SPACE_AFTER_SEPARATOR;
 
 static DEFAULT_SENTENCE_BREAK_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    let pattern = format!("[{}]+", GLOBAL_SENTENCE_TERMINATORS.join(""));
+    // Branch 1 (`\.(?:[ \t]+\.){2,}`) coalesces three-or-more spaced dots
+    // (`. . .`, `. . . .`) into one match. Two-dot `. .` is excluded so a
+    // period followed by a leading ellipsis (`raak. ...en`) is not eaten as a
+    // single run. `[ \t]` (not `\s`) keeps newlines intact for paragraph splits.
+    //
+    // Branch 2 (`[!?…](?:[ \t]+[!?…])+`) coalesces two-or-more spaced runs,
+    // mixed or homogeneous (`! !`, `? ? ?`, `! ?`, `… !`). `+` rather than
+    // `{2,}` is safe here — there's no leading-ellipsis equivalent for `!`/`?`.
+    // Both branches must precede the class for leftmost-first alternation.
+    let pattern = format!(
+        r"\.(?:[ \t]+\.){{2,}}|[!?…](?:[ \t]+[!?…])+|[{}]+",
+        GLOBAL_SENTENCE_TERMINATORS.join("")
+    );
+
     Regex::new(&pattern).unwrap()
 });
 
@@ -23,6 +36,20 @@ static CONTINUE_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[0-9a-z]
 // check with their own month lists.
 static CONTINUE_AFTER_NONWORD_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^\W*[0-9a-z]").unwrap());
+
+// Continuation rule for ellipsis matches: treat the run as mid-sentence when
+// the follow-up is whitespace + a lowercase/digit (`... no`, `. . . what`) or
+// whitespace + a standalone `I` (`... I'm`, `. . . I didn't`). `I` is the one
+// capital that can't be distinguished from a sentence start by case, so it's
+// folded in as continuation; `No`, `Then`, `And` still mark a boundary.
+static ELLIPSIS_CONTINUE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s+(?:[0-9a-z]|I(?:[\s'\u{2019}]|$))").unwrap());
+
+// Glued lowercase after an ellipsis (`mean...see`) is intra-utterance hesitation
+// and continues the sentence. Only fires when the dots are also glued behind -
+// a free-standing leading ellipsis (`raak. ...en`) keeps its boundary.
+static ELLIPSIS_GLUED_CONTINUE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[0-9a-z]").unwrap());
 
 static PARA_SPLIT_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\n[\r]*\n").unwrap());
 
@@ -133,6 +160,45 @@ fn push_if_increasing(boundaries: &mut Vec<usize>, boundary: usize) {
     if boundary > *boundaries.last().unwrap() {
         boundaries.push(boundary);
     }
+}
+
+/// Find terminator-run matches in `text`, folding a whitespace-separated
+/// dot-only follow-up onto a preceding `!`/`?`/`…` run so `Bravo ! .` and
+/// `Happy! . . . no one …` surface as one coalesced terminator.
+///
+/// The regex already coalesces homogeneous runs (`! !`, `. . .`) and
+/// contiguous mixed runs like `! ...` (matched by the contiguous-class
+/// branch as `!...`). Spaced mixed runs like `! . . .` can't be expressed
+/// without lookahead - `[!?…][ \t]+\.` would eat the first dot of an
+/// ellipsis - so they arrive here as two matches and are folded only when
+/// the follow-up is pure `.`s separated by whitespace.
+fn find_terminator_matches(text: &str, regex: &Regex) -> Vec<(usize, usize)> {
+    let mut out: Vec<(usize, usize)> = Vec::new();
+
+    for m in regex.find_iter(text) {
+        let (start, end) = (m.start(), m.end());
+
+        if let Some(last) = out.last_mut() {
+            let prev = &text[last.0..last.1];
+            let candidate = &text[start..end];
+            let gap = &text[last.1..start];
+
+            let is_blank = |c: char| matches!(c, ' ' | '\t');
+            let prev_is_emphatic = prev.ends_with(['!', '?', '…']);
+            let candidate_is_dot_run =
+                candidate.starts_with('.') && candidate.chars().all(|c| c == '.' || is_blank(c));
+            let separated_by_blanks = !gap.is_empty() && gap.chars().all(is_blank);
+
+            if prev_is_emphatic && candidate_is_dot_run && separated_by_blanks {
+                last.1 = end;
+                continue;
+            }
+        }
+
+        out.push((start, end));
+    }
+
+    out
 }
 
 /// Shared helper for languages that continue sentences before month names.
@@ -274,6 +340,7 @@ pub trait Language {
         // Pre-allocate sentence_boundaries once and reuse for all paragraphs
         let estimated_paragraph_sentences = 10; // reasonable default for typical paragraphs
         let mut sentence_boundaries = Vec::with_capacity(estimated_paragraph_sentences);
+        let sentence_break_regex = self.get_sentence_break_regex();
 
         for (pindex, paragraph) in paragraphs.iter().enumerate() {
             if pindex > 0 {
@@ -305,11 +372,7 @@ pub trait Language {
             sentence_boundaries.clear();
             sentence_boundaries.push(0);
 
-            let matches: Vec<(usize, usize)> = self
-                .get_sentence_break_regex()
-                .find_iter(paragraph)
-                .map(|m| (m.start(), m.end()))
-                .collect();
+            let matches = find_terminator_matches(paragraph, sentence_break_regex);
             let mut skippable_ranges = self.get_skippable_ranges(paragraph);
 
             // Detect list-item line starts once per paragraph and reuse the
@@ -735,7 +798,23 @@ pub trait Language {
     /// like abbreviations or mid-sentence punctuation.
     fn find_boundary(&self, text: &str, start: usize, end: usize) -> Option<usize> {
         let head = &text[..start];
-        let next_index = text.ceil_char_boundary(start + 1);
+        let matched = &text[start..end];
+
+        // Any coalesced multi-char terminator run (`...`, `!?`, `. . .`, `! ?`)
+        // allows leading whitespace before the lowercase continuation test, so
+        // `! ? is` and `... no` read as mid-sentence. `chars().nth(1)` rules out
+        // a single multi-byte terminator (`。`, `…`), which would otherwise look
+        // multi-char by byte length.
+        let is_multi_char_run = matched.chars().nth(1).is_some();
+
+        // For any multi-char match (e.g. `...`, `!?`, `!...`), scan continuation
+        // and trailing-space extension from the end of the run, not from one byte
+        // past its first char.
+        let next_index = if is_multi_char_run {
+            end
+        } else {
+            text.ceil_char_boundary(start + 1)
+        };
 
         let next_word_approx = self.get_next_word_approx(text, next_index);
 
@@ -745,7 +824,15 @@ pub trait Language {
             return Some(next_index + number_ref_match.end());
         }
 
-        if self.continue_in_next_word(next_word_approx) {
+        let continues = if is_multi_char_run {
+            ELLIPSIS_CONTINUE_REGEX.is_match(next_word_approx)
+                || (head.chars().next_back().is_some_and(|c| !c.is_whitespace())
+                    && ELLIPSIS_GLUED_CONTINUE_REGEX.is_match(next_word_approx))
+        } else {
+            self.continue_in_next_word(next_word_approx)
+        };
+
+        if continues {
             return None;
         }
 

--- a/src/languages/language.rs
+++ b/src/languages/language.rs
@@ -875,7 +875,15 @@ pub trait Language {
     /// the sentence is continuing rather than starting a new one. This helps avoid breaking
     /// sentences at abbreviations or in the middle of compound sentences.
     fn continue_in_next_word(&self, text_after_boundary: &str) -> bool {
-        CONTINUE_REGEX.is_match(text_after_boundary)
+        if CONTINUE_REGEX.is_match(text_after_boundary) {
+            return true;
+        }
+
+        // A comma following the terminator (after optional spaces) signals that
+        // the period is stray punctuation and the real clause continues. Treat
+        // it as a continuation rather than a boundary.
+        let trimmed = text_after_boundary.trim_start();
+        trimmed.as_bytes().first() == Some(&b',')
     }
 
     /// Identifies ranges of text that should be skipped during sentence boundary detection.

--- a/tests/en.txt
+++ b/tests/en.txt
@@ -437,3 +437,11 @@ And the music has a melody and a language in and of itself '' . Lead editor Naom
 And the music has a melody and a language in and of itself '' .
 Lead editor Naomi Zeichner went on to compare the album to the work of Interpol and '' the retro biker bar rock that soundtracks '' Sons of Anarchy '' '' .
 ===
+Continuing north to northeast LA 27 enters DeRidder as South Pine street and intersects with U.S. Route 171/U.S . Highway 190 at the northern terminus .
+---
+Continuing north to northeast LA 27 enters DeRidder as South Pine street and intersects with U.S. Route 171/U.S . Highway 190 at the northern terminus .
+===
+Hello Mr . Robinson how are you today?
+---
+Hello Mr . Robinson how are you today?
+===

--- a/tests/en.txt
+++ b/tests/en.txt
@@ -549,3 +549,19 @@ Really ? ? ? Then we should go .
 Really ? ? ?
 Then we should go .
 ===
+Nf6 , when 7.f4 and 7.Bg5 are the main possibilities for White . However , 6 ... d6 ! ? is an independent alternative for Black .
+---
+Nf6 , when 7.f4 and 7.Bg5 are the main possibilities for White .
+However , 6 ... d6 ! ? is an independent alternative for Black .
+===
+I wasn’t really ... well, what I mean...see . . . what I'm saying, the thing is . . . I didn’t mean it.
+---
+I wasn’t really ... well, what I mean...see . . . what I'm saying, the thing is . . . I didn’t mean it.
+===
+Hello world.Today is Tuesday.Mr. Smith went to the store and bought 1,000.That is a lot.
+---
+Hello world.
+Today is Tuesday.
+Mr. Smith went to the store and bought 1,000.
+That is a lot.
+===

--- a/tests/en.txt
+++ b/tests/en.txt
@@ -445,3 +445,107 @@ Hello Mr . Robinson how are you today?
 ---
 Hello Mr . Robinson how are you today?
 ===
+In 2006 , Slean teamed up with video director Nelson Chan ( '' Mary '' , '' Day One '' ) to create a three - part short film titled '' Tales of the Baroness '' . The first segment aired on 11 May 2007 on Bravo ! .
+---
+In 2006 , Slean teamed up with video director Nelson Chan ( '' Mary '' , '' Day One '' ) to create a three - part short film titled '' Tales of the Baroness '' .
+The first segment aired on 11 May 2007 on Bravo ! .
+===
+I wasn’t really ... well, what I mean...see . . . what I'm saying, the thing is . . . I didn’t mean it.
+---
+I wasn’t really ... well, what I mean...see . . . what I'm saying, the thing is . . . I didn’t mean it.
+===
+Pausing... for... thought... should not?
+---
+Pausing... for... thought... should not?
+===
+Happy . . .  no one had ever before said anything about wanting him to be happy.
+---
+Happy . . .  no one had ever before said anything about wanting him to be happy.
+===
+Happy ...  no one had ever before said anything about wanting him to be happy.
+---
+Happy ...  no one had ever before said anything about wanting him to be happy.
+===
+Happy...  no one had ever before said anything about wanting him to be happy.
+---
+Happy...  no one had ever before said anything about wanting him to be happy.
+===
+Happy . . .  No one had ever before said anything about wanting him to be happy.
+---
+Happy . . .
+No one had ever before said anything about wanting him to be happy.
+===
+Happy ...  No one had ever before said anything about wanting him to be happy.
+---
+Happy ...
+No one had ever before said anything about wanting him to be happy.
+===
+Happy... No one had ever before said anything about wanting him to be happy.
+---
+Happy...
+No one had ever before said anything about wanting him to be happy.
+===
+Happy! . . .  no one had ever before said anything about wanting him to be happy.
+---
+Happy! . . .  no one had ever before said anything about wanting him to be happy.
+===
+Happy! ...  no one had ever before said anything about wanting him to be happy.
+---
+Happy! ...  no one had ever before said anything about wanting him to be happy.
+===
+Happy!...  no one had ever before said anything about wanting him to be happy.
+---
+Happy!...  no one had ever before said anything about wanting him to be happy.
+===
+Happy! . . .  No one had ever before said anything about wanting him to be happy.
+---
+Happy! . . .
+No one had ever before said anything about wanting him to be happy.
+===
+Happy! ...  No one had ever before said anything about wanting him to be happy.
+---
+Happy! ...
+No one had ever before said anything about wanting him to be happy.
+===
+Happy!... No one had ever before said anything about wanting him to be happy.
+---
+Happy!...
+No one had ever before said anything about wanting him to be happy.
+===
+Happy? . . .  no one had ever before said anything about wanting him to be happy.
+---
+Happy? . . .  no one had ever before said anything about wanting him to be happy.
+===
+Happy? ...  no one had ever before said anything about wanting him to be happy.
+---
+Happy? ...  no one had ever before said anything about wanting him to be happy.
+===
+Happy?...  no one had ever before said anything about wanting him to be happy.
+---
+Happy?...  no one had ever before said anything about wanting him to be happy.
+===
+Happy? . . .  No one had ever before said anything about wanting him to be happy.
+---
+Happy? . . .
+No one had ever before said anything about wanting him to be happy.
+===
+Happy? ...  No one had ever before said anything about wanting him to be happy.
+---
+Happy? ...
+No one had ever before said anything about wanting him to be happy.
+===
+Happy?... No one had ever before said anything about wanting him to be happy.
+---
+Happy?...
+No one had ever before said anything about wanting him to be happy.
+===
+According to '' The Minish Cap '' , they were created to guard the Wind Tribe ! ! ! And there is a Minish - sized chamber inside them where they can be turned on or off .
+---
+According to '' The Minish Cap '' , they were created to guard the Wind Tribe ! ! !
+And there is a Minish - sized chamber inside them where they can be turned on or off .
+===
+Really ? ? ? Then we should go .
+---
+Really ? ? ?
+Then we should go .
+===

--- a/tests/en.txt
+++ b/tests/en.txt
@@ -570,3 +570,7 @@ The pineapple ( '' Ananas comosus '' ) is a sign from god that you need to brush
 The pineapple ( '' Ananas comosus '' ) is a sign from god that you need to brush more .
 It comes with with edible burritos that are filled with whipped cream. , It is not the most economically significant plant in the Bromeliaceae family .
 ===
+I thought... I would go.
+---
+I thought... I would go.
+===

--- a/tests/en.txt
+++ b/tests/en.txt
@@ -565,3 +565,8 @@ Today is Tuesday.
 Mr. Smith went to the store and bought 1,000.
 That is a lot.
 ===
+The pineapple ( '' Ananas comosus '' ) is a sign from god that you need to brush more . It comes with with edible burritos that are filled with whipped cream. , It is not the most economically significant plant in the Bromeliaceae family .
+---
+The pineapple ( '' Ananas comosus '' ) is a sign from god that you need to brush more .
+It comes with with edible burritos that are filled with whipped cream. , It is not the most economically significant plant in the Bromeliaceae family .
+===

--- a/tests/it.txt
+++ b/tests/it.txt
@@ -184,3 +184,9 @@ La macchina viaggiava a 100 km/h.
 ---
 La macchina viaggiava a 100 km/h.
 ===
+
+Aspetta... I gatti stanno miagolando.
+---
+Aspetta...
+I gatti stanno miagolando.
+===


### PR DESCRIPTION
* Generalises the ellipsis case so any mix of `.`, `!`, `?`, `…` repeated, spaced, or interleaved (`. . .`, `! ?`, `? ? ?`, `! ...`), etc., collapses into one boundary candidate instead of several.
* Continuation heuristics then decide whether the next token starts a new sentence: uppercase non-`I` splits; lowercase, digits, or glued continuations (`mean... see`) keep the sentence intact, but `mean... See` starts a new sentence.
* Makes sure the Dutch example where a period space is followed by ellipse and a word is preserved, e.g., `raak. ...en`

While assessing the punctuation run case, the following issues also came to light and were addressed:
* Stray period before comma (`ice cream. , It was…`) is treated as continuation.
* Dot-coded tokens like chess moves (`7.Bg5`, `1.e4`) no longer emit a boundary.
* Slash-joined abbreviations (`171/U.S.`) split on / when extracting the trailing word so the right-hand abbreviation is still recognised. Whitespace between abbreviation and terminator (`U.S .`) is also tolerated.

* Added test cases including the example from issue #11.
* Updated README.