### PR TITLE
Fix 2 `get_sentence_boundaries` panics

### DIFF
--- a/src/languages/language.rs
+++ b/src/languages/language.rs
@@ -339,32 +339,34 @@ pub trait Language {
         let mut boundaries = Vec::with_capacity(estimated_sentences);
 
         // Split by paragraph breaks (one or more newlines with optional whitespace)
-        let paragraphs: Vec<&str> = PARA_SPLIT_REGEX.split(text).collect();
-
-        // Pre-calculate all paragraph offsets in one pass
         // CRITICAL: We track both byte offsets AND character offsets separately.
-        // This is essential for correct handling of multi-byte UTF-8 characters (e.g., CJK, emoji).
-        //
-        // - `paragraph_offsets`: byte indices into the original text (for slicing with &text[start..end])
-        // - `paragraph_char_offsets`: character counts (for SentenceBoundary.start_index/end_index)
-        //
-        // Example: "日本語" is 3 characters but 9 bytes in UTF-8:
+        // This is essential for correct handling of multi-byte UTF-8 characters like CJK and emojis.
+        // Example: "日本語" is 3 characters but 9 bytes:
         //   - byte offset: 0..9
         //   - char offset: 0..3
-        let mut paragraph_offsets = Vec::with_capacity(paragraphs.len());
-        let mut current_offset = 0;
-        let mut paragraph_char_offsets = Vec::with_capacity(paragraphs.len());
+        // Roughly estimate 4 sentences per paragraph
+        let estimated_paragraphs = (estimated_sentences / 4).max(1);
+        let mut paragraphs: Vec<&str> = Vec::with_capacity(estimated_paragraphs);
+        let mut paragraph_offsets: Vec<usize> = Vec::with_capacity(estimated_paragraphs);
+        let mut paragraph_char_offsets: Vec<usize> = Vec::with_capacity(estimated_paragraphs);
+
+        let mut last_end = 0;
         let mut current_char_offset = 0;
-        for (i, paragraph) in paragraphs.iter().enumerate() {
-            paragraph_offsets.push(current_offset);
+        for m in PARA_SPLIT_REGEX.find_iter(text) {
+            let paragraph = &text[last_end..m.start()];
+            paragraphs.push(paragraph);
+            paragraph_offsets.push(last_end);
             paragraph_char_offsets.push(current_char_offset);
-            current_offset += paragraph.len();
-            current_char_offset += paragraph.chars().count();
-            if i < paragraphs.len() - 1 {
-                current_offset += 2; // for "\n\n" bytes
-                current_char_offset += 2; // for "\n\n" chars (always 2, regardless of encoding)
-            }
+
+            let separator_chars = text[m.start()..m.end()].chars().count();
+            current_char_offset += paragraph.chars().count() + separator_chars;
+            last_end = m.end();
         }
+
+        // Final paragraph after the last separator (the whole text if none).
+        paragraphs.push(&text[last_end..]);
+        paragraph_offsets.push(last_end);
+        paragraph_char_offsets.push(current_char_offset);
 
         // Pre-allocate sentence_boundaries once and reuse for all paragraphs
         let estimated_paragraph_sentences = 10; // reasonable default for typical paragraphs
@@ -374,13 +376,16 @@ pub trait Language {
         for (pindex, paragraph) in paragraphs.iter().enumerate() {
             if pindex > 0 {
                 let paragraph_start = paragraph_offsets[pindex];
+                let separator_start = paragraph_offsets[pindex - 1] + paragraphs[pindex - 1].len();
+                let separator = &text[separator_start..paragraph_start];
                 let paragraph_char_start = paragraph_char_offsets[pindex];
+
                 boundaries.push(SentenceBoundary {
-                    start_index: paragraph_char_start - 2,
+                    start_index: paragraph_char_start - separator.chars().count(),
                     end_index: paragraph_char_start,
-                    start_byte: paragraph_start - 2,
+                    start_byte: paragraph_start - separator.len(),
                     end_byte: paragraph_start,
-                    text: "\n\n",
+                    text: separator,
                     boundary_symbol: None,
                     is_paragraph_break: true,
                 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -812,4 +812,35 @@ mod tests {
             "Text reconstruction failed with mixed whitespace"
         );
     }
+
+    #[test]
+    fn test_get_sentence_boundaries_handles_multibyte_across_chunks() {
+        const CHUNK_SIZE: usize = 10 * 1024;
+        let para = format!("{}end’.", "Filler sentence number one here. ".repeat(160));
+        let text = format!("{para}\n\n{para}\n\n{para}");
+        let boundaries = get_sentence_boundaries("en", &text);
+
+        assert!(!boundaries.is_empty());
+        assert_eq!(boundaries.last().unwrap().end_index, text.chars().count());
+
+        for w in boundaries.windows(2) {
+            assert!(
+                w[0].end_index <= w[1].start_index,
+                "char indices regressed: {} > {}",
+                w[0].end_index,
+                w[1].start_index,
+            );
+
+            assert!(
+                w[0].end_byte <= w[1].start_byte,
+                "byte offsets regressed: {} > {}",
+                w[0].end_byte,
+                w[1].start_byte,
+            );
+        }
+
+        for b in &boundaries {
+            assert_eq!(b.text, &text[b.start_byte..b.end_byte]);
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -806,4 +806,24 @@ mod tests {
             assert_eq!(b.text, &text[b.start_byte..b.end_byte]);
         }
     }
+
+    #[test]
+    fn test_get_sentence_boundaries_paragraph_separator_offsets() {
+        let para = format!("{}’", "Filler sentence here. ".repeat(150));
+        let text = std::iter::repeat(para.as_str())
+            .take(6)
+            .collect::<Vec<_>>()
+            .join("\r\n\r\n");
+        assert!(text.len() > 10 * 1024, "input must exceed the chunk size");
+
+        let boundaries = get_sentence_boundaries("en", &text);
+
+        for b in &boundaries {
+            assert_eq!(
+                b.text,
+                &text[b.start_byte..b.end_byte],
+                "byte offsets must reconstruct boundary text (CRLF separator drift)"
+            );
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,86 +85,50 @@ pub fn language_factory(language_code: &str) -> Box<dyn Language> {
     }
 }
 
-fn chunk_text(text: &str, chunk_size: usize) -> Vec<&str> {
+fn paragraph_spans(text: &str) -> Vec<(usize, usize)> {
+    let mut spans = Vec::new();
+    let mut next_start = 0;
+
+    for sep in PARA_SPLIT_REGEX.find_iter(text) {
+        spans.push((next_start, sep.start()));
+        next_start = sep.end();
+    }
+
+    if next_start < text.len() {
+        spans.push((next_start, text.len()));
+    }
+
+    spans
+}
+
+/// Split `text` into chunks of at most `chunk_size` bytes at paragraph
+/// boundaries. Returns `(byte_offset, chunk)` pairs.
+fn chunk_text(text: &str, chunk_size: usize) -> Vec<(usize, &str)> {
     if chunk_size == 0 || text.len() <= chunk_size {
-        return vec![text];
+        return vec![(0, text)];
     }
 
-    let mut chunks = Vec::new();
+    let mut chunks: Vec<(usize, &str)> = Vec::with_capacity(text.len() / chunk_size + 1);
+    let mut chunk: Option<(usize, usize)> = None;
 
-    // Split by paragraph breaks (one or more newlines with optional whitespace)
-    // Get paragraph parts and their positions
-    let mut paragraphs = Vec::new();
-    let mut last_end = 0;
-
-    for mat in PARA_SPLIT_REGEX.find_iter(text) {
-        // Add the text before this match
-        paragraphs.push((last_end, mat.start()));
-        last_end = mat.end();
-    }
-    // Add the final paragraph
-    if last_end < text.len() {
-        paragraphs.push((last_end, text.len()));
-    }
-
-    if paragraphs.is_empty() {
-        return vec![text];
-    }
-
-    let mut current_start = 0;
-    let mut current_end = 0;
-    let mut i = 0;
-
-    while i < paragraphs.len() {
-        let (para_start, para_end) = paragraphs[i];
-        let para_size = para_end - para_start;
-
-        if para_size > chunk_size {
-            if current_end > current_start {
-                let safe_end = text.ceil_char_boundary(current_end);
-                chunks.push(&text[current_start..safe_end]);
-                current_start = 0;
-                current_end = 0;
+    for (start, end) in paragraph_spans(text) {
+        match chunk {
+            Some((chunk_start, _)) if end - chunk_start <= chunk_size => {
+                chunk = Some((chunk_start, end));
             }
 
-            // Paragraph exceeds chunk_size but has no \n\n boundary to split on.
-            // Pass it through whole to avoid splitting mid-sentence or mid-word.
-            chunks.push(&text[para_start..para_end]);
-            i += 1;
-            continue;
+            _ => {
+                if let Some((chunk_start, chunk_end)) = chunk {
+                    chunks.push((chunk_start, &text[chunk_start..chunk_end]));
+                }
+
+                chunk = Some((start, end));
+            }
         }
-
-        // If this is the first paragraph in the chunk
-        if current_end == current_start {
-            current_start = para_start;
-            current_end = para_end;
-            i += 1;
-            continue;
-        }
-
-        // Check if adding this paragraph would exceed chunk_size
-        let potential_size = para_end - current_start;
-
-        if potential_size > chunk_size {
-            // Finalize current chunk
-            let safe_end = text.ceil_char_boundary(current_end);
-            chunks.push(&text[current_start..safe_end]);
-
-            // Start new chunk with current paragraph
-            current_start = para_start;
-            current_end = para_end;
-        } else {
-            // Add this paragraph to current chunk
-            current_end = para_end;
-        }
-
-        i += 1;
     }
 
-    // Add the final chunk if there's remaining content
-    if current_end > current_start {
-        let safe_end = text.ceil_char_boundary(current_end);
-        chunks.push(&text[current_start..safe_end]);
+    if let Some((chunk_start, chunk_end)) = chunk {
+        chunks.push((chunk_start, &text[chunk_start..chunk_end]));
     }
 
     chunks
@@ -205,9 +169,9 @@ pub fn segment<'a>(language_code: &str, text: &'a str) -> Vec<&'a str> {
     if text.len() > CHUNK_SIZE {
         let chunks = chunk_text(text, CHUNK_SIZE);
         let mut all_sentences = Vec::new();
-        for chunk in chunks {
-            let chunk_sentences = language.segment(chunk);
-            all_sentences.extend(chunk_sentences);
+
+        for (_offset, chunk) in chunks {
+            all_sentences.extend(language.segment(chunk));
         }
 
         all_sentences
@@ -225,8 +189,8 @@ pub fn segment<'a>(language_code: &str, text: &'a str) -> Vec<&'a str> {
 /// For texts larger than 10KB, the function chunks the text at paragraph boundaries
 /// (`\n\n`) to process large inputs efficiently. Paragraphs that exceed 10KB and
 /// contain no internal paragraph breaks are processed as a single unit to avoid
-/// splitting mid-sentence or mid-word. The returned boundaries maintain correct
-/// indices relative to the original text.
+/// splitting mid-sentence or mid-word. The returned character indices and byte
+/// offsets are correct relative to the original text.
 ///
 /// # Arguments
 ///
@@ -239,6 +203,9 @@ pub fn segment<'a>(language_code: &str, text: &'a str) -> Vec<&'a str> {
 /// Each `SentenceBoundary` includes:
 /// - `start_index`: The character index (Unicode scalar count) where the sentence starts
 /// - `end_index`: The character index (Unicode scalar count) where the sentence ends
+/// - `start_byte`: The byte offset into the original `text` where the sentence starts
+/// - `end_byte`: The byte offset into the original `text` where the sentence ends
+///   (`&text[start_byte..end_byte]` reproduces the sentence under normal operation)
 /// - `text`: A reference to the sentence text (zero-copy)
 /// - `boundary_symbol`: The punctuation mark that ended the sentence (if any)
 /// - `is_paragraph_break`: Whether this boundary represents a paragraph break ("\n\n")
@@ -268,25 +235,21 @@ pub fn get_sentence_boundaries<'a>(
     if text.len() > CHUNK_SIZE {
         let chunks = chunk_text(text, CHUNK_SIZE);
         let mut all_boundaries = Vec::new();
-        let mut chunk_offset = 0;
+        let mut prev_end_byte = 0usize;
+        let mut prev_end_index = 0usize;
 
-        for chunk in chunks {
-            let chunk_boundaries = language.get_sentence_boundaries(chunk);
-
-            // Adjust indices to be relative to original text
-            let mut prev_end_index = 0;
-            for boundary in chunk_boundaries {
+        for (chunk_offset, chunk) in chunks {
+            for boundary in language.get_sentence_boundaries(chunk) {
                 let start_byte = boundary.start_byte + chunk_offset;
                 let end_byte = boundary.end_byte + chunk_offset;
 
-                let start_index = if prev_end_index > 0 {
+                let start_index = if start_byte == prev_end_byte {
                     prev_end_index
                 } else {
-                    text[..start_byte].chars().count()
+                    prev_end_index + text[prev_end_byte..start_byte].chars().count()
                 };
 
                 let end_index = start_index + boundary.text.chars().count();
-                prev_end_index = end_index;
 
                 all_boundaries.push(SentenceBoundary {
                     start_index,
@@ -297,9 +260,10 @@ pub fn get_sentence_boundaries<'a>(
                     boundary_symbol: boundary.boundary_symbol,
                     is_paragraph_break: boundary.is_paragraph_break,
                 });
-            }
 
-            chunk_offset += chunk.len();
+                prev_end_byte = end_byte;
+                prev_end_index = end_index;
+            }
         }
 
         all_boundaries
@@ -362,9 +326,9 @@ mod tests {
         let text = "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.";
         let chunks = chunk_text(text, 20);
         assert_eq!(chunks.len(), 3);
-        assert_eq!(chunks[0], "First paragraph.");
-        assert_eq!(chunks[1], "Second paragraph.");
-        assert_eq!(chunks[2], "Third paragraph.");
+        assert_eq!(chunks[0], (0, "First paragraph."));
+        assert_eq!(chunks[1], (18, "Second paragraph."));
+        assert_eq!(chunks[2], (37, "Third paragraph."));
     }
 
     #[test]
@@ -375,7 +339,7 @@ mod tests {
             "This is a long text without paragraph breaks that should be returned as one chunk.";
         let chunks = chunk_text(text, 20);
         assert_eq!(chunks.len(), 1);
-        assert_eq!(chunks[0], text);
+        assert_eq!(chunks[0], (0, text));
     }
 
     #[test]
@@ -815,7 +779,6 @@ mod tests {
 
     #[test]
     fn test_get_sentence_boundaries_handles_multibyte_across_chunks() {
-        const CHUNK_SIZE: usize = 10 * 1024;
         let para = format!("{}end’.", "Filler sentence number one here. ".repeat(160));
         let text = format!("{para}\n\n{para}\n\n{para}");
         let boundaries = get_sentence_boundaries("en", &text);


### PR DESCRIPTION
Addresses 2 bugs in `get_sentence_boundaries` that caused panics in the Shakespeare corpus.

* `get_sentence_boundaries` (`lib.rs`) was panicking when the chunk size boundary fell in the middle of a multibyte UTF-8 character. Refactored to track byte offsets alongside chunk slices so that character boundaries are respected correctly.
* `get_sentence_boundaries` (`library.rs`) was panicking due to the hardcoded `+= 2` offsets for paragraph splits.  The regex `\n[\r]*\n` can result in more than just 2 byte offsets sometimes.  Changed the hard coded offset to an exact separator length calculation.
* The `ceil_char_boundary` was probably also masking some of this behaviour before in some cases.  The new calculation should land on char boundaries now so the `ceil_char_boundary` becomes a noop, and is removed.  It also means if another arithemtic error surfaces in that section of code, it should panic rather than quietly produce bad boundaries.