### PR TITLE
nodejs: add TypeScript declarations (#69)

### DIFF
--- a/bindings/nodejs/index.d.ts
+++ b/bindings/nodejs/index.d.ts
@@ -1,0 +1,21 @@
+export interface SentenceBoundary {
+  /** Character index where the sentence starts. */
+  start_index: number;
+  /** Character index where the sentence ends. */
+  end_index: number;
+  /** The sentence text. */
+  text: string;
+  /** Punctuation mark that ended the sentence, or null if none. */
+  boundary_symbol: string | null;
+  /** Whether this boundary represents a paragraph break ("\n\n"). */
+  is_paragraph_break: boolean;
+}
+
+export function segment(language: string, text: string): string[];
+export function get_sentence_boundaries(
+  language: string,
+  text: string,
+): SentenceBoundary[];
+
+declare const _default: typeof segment;
+export default _default;

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -4,6 +4,7 @@
   "description": "sentence segmentation library",
   "type": "module",
   "main": "index.cjs",
+  "types": "./index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wikimedia/sentencex.git"
@@ -24,14 +25,15 @@
     "*.cjs",
     "*.mjs",
     "*.js",
+    "*.d.ts",
     "*.md",
     "LICENSE",
     "*.node"
   ],
   "exports": {
     ".": {
-    "require": "./index.cjs",
-    "import": "./index.mjs"
+      "require": { "types": "./index.d.ts", "default": "./index.cjs" },
+      "import": { "types": "./index.d.ts", "default": "./index.mjs" }
     }
   },
   "optionalDependencies": {

--- a/bindings/nodejs/test.js
+++ b/bindings/nodejs/test.js
@@ -65,6 +65,11 @@ describe("sentencex", () => {
         assert(typeof boundary.start_index === "number");
         assert(typeof boundary.end_index === "number");
         assert(typeof boundary.text === "string");
+        assert(
+          boundary.boundary_symbol === null ||
+            typeof boundary.boundary_symbol === "string",
+        );
+        assert(typeof boundary.is_paragraph_break === "boolean");
       });
     });
 


### PR DESCRIPTION
Add index.d.ts declaring SentenceBoundary, segment() and get_sentence_boundaries(), and wire it up via the package "types" field and per-condition "types" entries in the exports map so both classic and node16/nodenext resolution find it. Include *.d.ts in the published files list and extend the boundary tests to cover boundary_symbol / is_paragraph_break.