### PR TITLE
SentenceBoundary.boundary_symbol api change

### DIFF
--- a/src/languages/language.rs
+++ b/src/languages/language.rs
@@ -750,7 +750,7 @@ pub trait Language {
                         .next_back()
                         .and_then(|(idx, ch)| {
                             if is_sentence_terminator(ch) {
-                                Some(trimmed_slice[idx..].to_string())
+                                Some(&trimmed_slice[idx..])
                             } else {
                                 None
                             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub struct SentenceBoundary<'a> {
     pub start_byte: usize,
     pub end_byte: usize,
     pub text: &'a str,
-    pub boundary_symbol: Option<String>,
+    pub boundary_symbol: Option<&'a str>,
     pub is_paragraph_break: bool,
 }
 


### PR DESCRIPTION
Change `SentenceBoundary::boundary_symbol` from `Option<String>` to `Option<&'a str>`.

From what I can tell, the safety impact is only on native Rust library consumers.  They will get a slice instead of an owned string. Consumers who want to use the symbol string without retaining the original text will need to make a copy, e.g., with a `to_owned()`.

Library users in other languages should be unaffected.  Python and Node seem to make copies when they marshal. WASM goes through json process so ends up with a copy. C# reconstructs from byte offsets instead of marshalling so also ends up with a copy.

The benefit of this change is that you cut down on string allocations.  For non native consumers, those allocations are always wasted since they end up making their own copies anyway. The runtime cost savings are small but measurable.
